### PR TITLE
Consumo Monitor: cost dashboard + services registry + usage_report MCP

### DIFF
--- a/convex/agents.ts
+++ b/convex/agents.ts
@@ -108,3 +108,12 @@ export const getLogs = query({
       .take(args.limit ?? 500);
   },
 });
+
+export const recentLogs = query({
+  args: { sinceMs: v.number(), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? 10_000;
+    const logs = await ctx.db.query("agentLogs").order("desc").take(limit);
+    return logs.filter((l) => l._creationTime >= args.sinceMs);
+  },
+});

--- a/convex/automations.ts
+++ b/convex/automations.ts
@@ -52,6 +52,16 @@ export const get = query({
   },
 });
 
+export const getByName = query({
+  args: { name: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("automations")
+      .filter((q) => q.eq(q.field("name"), args.name))
+      .first();
+  },
+});
+
 export const setEnabled = mutation({
   args: { automationId: v.string(), enabled: v.boolean() },
   handler: async (ctx, args) => {

--- a/convex/lib/anomalies.test.ts
+++ b/convex/lib/anomalies.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { detectAnomalies, type UsageRow } from "./anomalies.js";
+
+const dayMs = 24 * 60 * 60 * 1000;
+const now = new Date("2026-04-28T12:00:00Z").getTime();
+
+function row(partial: Partial<UsageRow> = {}): UsageRow {
+  return {
+    _id: "r" + Math.random().toString(36).slice(2),
+    source: "dispatcher",
+    conversationId: "conv1",
+    model: "claude-sonnet-4-6",
+    inputTokens: 1000,
+    outputTokens: 500,
+    cacheReadTokens: 4000,
+    cacheCreationTokens: 0,
+    costUsd: 0.01,
+    createdAt: now,
+    ...partial,
+  };
+}
+
+describe("detectAnomalies", () => {
+  it("flags cost spike when 7d > 2x median of prior 4 weeks", () => {
+    const rows: UsageRow[] = [];
+    // 4 prior weeks at $0.10 each
+    for (let w = 1; w <= 4; w++) {
+      rows.push(row({ costUsd: 0.1, createdAt: now - w * 7 * dayMs - dayMs }));
+    }
+    // current week at $0.50 (5x median)
+    rows.push(row({ costUsd: 0.5, createdAt: now - dayMs }));
+
+    const result = detectAnomalies(rows, "7d", now);
+    const spike = result.find((a) => a.kind === "cost_spike");
+    expect(spike).toBeDefined();
+    expect(spike?.severity).toBe("high");
+  });
+
+  it("does not flag cost spike when fewer than 2 prior weeks of data", () => {
+    const rows: UsageRow[] = [
+      row({ costUsd: 0.5, createdAt: now - dayMs }),
+      row({ costUsd: 0.1, createdAt: now - 8 * dayMs }),
+    ];
+    const result = detectAnomalies(rows, "7d", now);
+    expect(result.find((a) => a.kind === "cost_spike")).toBeUndefined();
+  });
+
+  it("flags low cache hit when dispatcher rate < 0.5 with >= 10 calls", () => {
+    const rows: UsageRow[] = [];
+    for (let i = 0; i < 12; i++) {
+      rows.push(
+        row({
+          source: "dispatcher",
+          inputTokens: 1000,
+          cacheReadTokens: 100, // hit rate ~9%
+          createdAt: now - i * 60_000,
+        }),
+      );
+    }
+    const result = detectAnomalies(rows, "7d", now);
+    const low = result.find((a) => a.kind === "low_cache_hit");
+    expect(low).toBeDefined();
+    expect(low?.severity).toBe("medium");
+  });
+
+  it("does not flag low cache hit with fewer than 10 calls", () => {
+    const rows: UsageRow[] = [];
+    for (let i = 0; i < 5; i++) {
+      rows.push(row({ inputTokens: 1000, cacheReadTokens: 0 }));
+    }
+    const result = detectAnomalies(rows, "7d", now);
+    expect(result.find((a) => a.kind === "low_cache_hit")).toBeUndefined();
+  });
+
+  it("flags broken cache when >= 5 dispatcher turns lose cache within TTL", () => {
+    const rows: UsageRow[] = [];
+    // First turn (always cold), then 6 quick turns with cacheReadTokens=0
+    rows.push(
+      row({
+        cacheReadTokens: 5000,
+        inputTokens: 100,
+        createdAt: now - 60_000 * 7,
+      }),
+    );
+    for (let i = 6; i >= 1; i--) {
+      rows.push(
+        row({
+          cacheReadTokens: 0,
+          inputTokens: 5000,
+          createdAt: now - 60_000 * i, // 1 min apart, all within 5min TTL
+        }),
+      );
+    }
+    const result = detectAnomalies(rows, "7d", now);
+    const broken = result.find((a) => a.kind === "broken_cache");
+    expect(broken).toBeDefined();
+  });
+
+  it("flags giant turn when input + cacheRead > 100k", () => {
+    const rows: UsageRow[] = [
+      row({ inputTokens: 60_000, cacheReadTokens: 50_000, _id: "BIG" }),
+    ];
+    const result = detectAnomalies(rows, "7d", now);
+    const big = result.find((a) => a.kind === "giant_turn");
+    expect(big).toBeDefined();
+    expect(big?.ref).toEqual({ recordId: "BIG", agentId: undefined });
+  });
+
+  it("returns empty array on empty input", () => {
+    expect(detectAnomalies([], "7d", now)).toEqual([]);
+  });
+});

--- a/convex/lib/anomalies.ts
+++ b/convex/lib/anomalies.ts
@@ -1,0 +1,136 @@
+import { rangeStart, type RangeKey } from "./timeRange.js";
+
+export interface UsageRow {
+  _id: string;
+  source: string;
+  conversationId?: string;
+  agentId?: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  costUsd: number;
+  createdAt: number;
+}
+
+export type AnomalyKind =
+  | "cost_spike"
+  | "low_cache_hit"
+  | "broken_cache"
+  | "giant_turn";
+
+export interface Anomaly {
+  kind: AnomalyKind;
+  severity: "low" | "medium" | "high";
+  message: string;
+  ref?: { recordId?: string; agentId?: string };
+}
+
+const dayMs = 24 * 60 * 60 * 1000;
+const weekMs = 7 * dayMs;
+const fiveMinMs = 5 * 60 * 1000;
+const GIANT_TURN_THRESHOLD = 100_000;
+const LOW_CACHE_HIT_MIN_CALLS = 10;
+const LOW_CACHE_HIT_THRESHOLD = 0.5;
+const BROKEN_CACHE_MIN_OCCURRENCES = 5;
+const COST_SPIKE_MULTIPLIER = 2;
+
+/**
+ * Detect anomalies over the given rows. Cost-spike heuristic uses fixed 7d/4w
+ * windows independent of `range`; the others honor `range` (which is encoded
+ * in which rows the caller provides).
+ */
+export function detectAnomalies(
+  rows: UsageRow[],
+  range: RangeKey,
+  now: number = Date.now(),
+): Anomaly[] {
+  const anomalies: Anomaly[] = [];
+
+  // 1. Cost spike: this week vs median of prior 4 weeks
+  const weekBoundary = now - weekMs;
+  const fourWeeksAgo = now - 5 * weekMs;
+  const thisWeek = rows
+    .filter((r) => r.createdAt >= weekBoundary && r.createdAt < now)
+    .reduce((s, r) => s + r.costUsd, 0);
+  const priorByWeek: number[] = [0, 0, 0, 0];
+  for (const r of rows) {
+    if (r.createdAt < fourWeeksAgo || r.createdAt >= weekBoundary) continue;
+    const w = Math.floor((weekBoundary - r.createdAt) / weekMs);
+    if (w >= 0 && w < 4) priorByWeek[w] += r.costUsd;
+  }
+  const priorWithData = priorByWeek.filter((w) => w > 0);
+  if (priorWithData.length >= 2) {
+    const median = medianOf(priorWithData);
+    if (median > 0 && thisWeek > COST_SPIKE_MULTIPLIER * median) {
+      anomalies.push({
+        kind: "cost_spike",
+        severity: "high",
+        message: `Esta semana: $${thisWeek.toFixed(2)} vs mediana das semanas anteriores: $${median.toFixed(2)}`,
+      });
+    }
+  }
+
+  // 2. Low cache hit on dispatcher in `range`
+  const rangeStartMs = rangeStart(range, now);
+  const dispatcherInRange = rows.filter(
+    (r) => r.source === "dispatcher" && r.createdAt >= rangeStartMs,
+  );
+  if (dispatcherInRange.length >= LOW_CACHE_HIT_MIN_CALLS) {
+    const cacheRead = dispatcherInRange.reduce((s, r) => s + r.cacheReadTokens, 0);
+    const input = dispatcherInRange.reduce((s, r) => s + r.inputTokens, 0);
+    const denom = cacheRead + input;
+    const rate = denom > 0 ? cacheRead / denom : 0;
+    if (rate < LOW_CACHE_HIT_THRESHOLD) {
+      anomalies.push({
+        kind: "low_cache_hit",
+        severity: "medium",
+        message: `Dispatcher cache hit ${(rate * 100).toFixed(0)}% (alvo >= 70%)`,
+      });
+    }
+  }
+
+  // 3. Broken cache on dispatcher in `range`
+  const dispatcherSorted = dispatcherInRange
+    .filter((r) => r.conversationId)
+    .sort((a, b) => a.createdAt - b.createdAt);
+  const lastByConv = new Map<string, number>();
+  let broken = 0;
+  for (const r of dispatcherSorted) {
+    const prev = lastByConv.get(r.conversationId!);
+    if (prev !== undefined && r.createdAt - prev <= fiveMinMs && r.cacheReadTokens === 0) {
+      broken += 1;
+    }
+    lastByConv.set(r.conversationId!, r.createdAt);
+  }
+  if (broken >= BROKEN_CACHE_MIN_OCCURRENCES) {
+    anomalies.push({
+      kind: "broken_cache",
+      severity: "medium",
+      message: `${broken} turnos do dispatcher perderam cache dentro do TTL de 5 min`,
+    });
+  }
+
+  // 4. Giant turn(s) in range
+  for (const r of rows) {
+    if (r.createdAt < rangeStartMs) continue;
+    if (r.inputTokens + r.cacheReadTokens > GIANT_TURN_THRESHOLD) {
+      const totalK = ((r.inputTokens + r.cacheReadTokens) / 1000).toFixed(0);
+      anomalies.push({
+        kind: "giant_turn",
+        severity: "low",
+        message: `Chamada ${r.source} com ${totalK}k tokens de contexto`,
+        ref: { recordId: r._id, agentId: r.agentId },
+      });
+    }
+  }
+
+  return anomalies;
+}
+
+function medianOf(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}

--- a/convex/lib/anomalies.ts
+++ b/convex/lib/anomalies.ts
@@ -48,19 +48,25 @@ export function detectAnomalies(
 ): Anomaly[] {
   const anomalies: Anomaly[] = [];
 
-  // 1. Cost spike: this week vs median of prior 4 weeks
+  // 1. Cost spike: this week vs median of prior 4 weeks. "Has data" means the
+  // week had at least one row, not that costUsd > 0 — a quiet $0 week is real
+  // signal, and excluding it would inflate the median and hide spikes.
   const weekBoundary = now - weekMs;
   const fourWeeksAgo = now - 5 * weekMs;
   const thisWeek = rows
     .filter((r) => r.createdAt >= weekBoundary && r.createdAt < now)
     .reduce((s, r) => s + r.costUsd, 0);
   const priorByWeek: number[] = [0, 0, 0, 0];
+  const priorHasRows: boolean[] = [false, false, false, false];
   for (const r of rows) {
     if (r.createdAt < fourWeeksAgo || r.createdAt >= weekBoundary) continue;
     const w = Math.floor((weekBoundary - r.createdAt) / weekMs);
-    if (w >= 0 && w < 4) priorByWeek[w] += r.costUsd;
+    if (w >= 0 && w < 4) {
+      priorByWeek[w] += r.costUsd;
+      priorHasRows[w] = true;
+    }
   }
-  const priorWithData = priorByWeek.filter((w) => w > 0);
+  const priorWithData = priorByWeek.filter((_, i) => priorHasRows[i]);
   if (priorWithData.length >= 2) {
     const median = medianOf(priorWithData);
     if (median > 0 && thisWeek > COST_SPIKE_MULTIPLIER * median) {
@@ -86,7 +92,7 @@ export function detectAnomalies(
       anomalies.push({
         kind: "low_cache_hit",
         severity: "medium",
-        message: `Dispatcher cache hit ${(rate * 100).toFixed(0)}% (alvo >= 70%)`,
+        message: `Dispatcher cache hit ${(rate * 100).toFixed(0)}% (abaixo do alvo de 50%)`,
       });
     }
   }

--- a/convex/lib/pricing.ts
+++ b/convex/lib/pricing.ts
@@ -1,0 +1,54 @@
+// Anthropic Claude pricing in USD per million tokens. Update when prices change.
+// Used to compute savedUsd estimates (cache read vs uncached input). costUsd
+// itself comes from the SDK's msg.total_cost_usd, so this table is only for the
+// "you saved $X by caching" calculation.
+
+export interface ModelPrice {
+  inputPerMTok: number;
+  outputPerMTok: number;
+  cacheReadPerMTok: number;
+  cacheWritePerMTok: number;
+}
+
+const PRICES: Record<string, ModelPrice> = {
+  // Sonnet family (claude-sonnet-4-6, claude-sonnet-4-6-YYYYMMDD)
+  "claude-sonnet-4-6": {
+    inputPerMTok: 3,
+    outputPerMTok: 15,
+    cacheReadPerMTok: 0.3,
+    cacheWritePerMTok: 3.75,
+  },
+  // Opus family (claude-opus-4-7, claude-opus-4-7-YYYYMMDD)
+  "claude-opus-4-7": {
+    inputPerMTok: 15,
+    outputPerMTok: 75,
+    cacheReadPerMTok: 1.5,
+    cacheWritePerMTok: 18.75,
+  },
+  // Haiku family (claude-haiku-4-5, claude-haiku-4-5-YYYYMMDD)
+  "claude-haiku-4-5": {
+    inputPerMTok: 1,
+    outputPerMTok: 5,
+    cacheReadPerMTok: 0.1,
+    cacheWritePerMTok: 1.25,
+  },
+};
+
+const DEFAULT_PRICE: ModelPrice = PRICES["claude-sonnet-4-6"];
+
+export function priceFor(model: string): ModelPrice {
+  // Direct hit
+  if (PRICES[model]) return PRICES[model];
+  // Prefix match: SDK appends -YYYYMMDD to date-stamped variants
+  for (const key of Object.keys(PRICES)) {
+    if (model.startsWith(key)) return PRICES[key];
+  }
+  return DEFAULT_PRICE;
+}
+
+/** Estimate the dollars saved by reading from cache vs paying full input rate. */
+export function savedFromCacheRead(model: string, cacheReadTokens: number): number {
+  const p = priceFor(model);
+  const savedPerMTok = p.inputPerMTok - p.cacheReadPerMTok;
+  return (cacheReadTokens * savedPerMTok) / 1_000_000;
+}

--- a/convex/lib/timeRange.ts
+++ b/convex/lib/timeRange.ts
@@ -1,0 +1,21 @@
+export type RangeKey = "today" | "7d" | "30d" | "all";
+
+export const RANGE_VALUES: RangeKey[] = ["today", "7d", "30d", "all"];
+
+/** Returns ms-since-epoch lower bound for `range`. `all` returns 0. */
+export function rangeStart(range: RangeKey, now: number = Date.now()): number {
+  const dayMs = 24 * 60 * 60 * 1000;
+  switch (range) {
+    case "today": {
+      const d = new Date(now);
+      d.setHours(0, 0, 0, 0);
+      return d.getTime();
+    }
+    case "7d":
+      return now - 7 * dayMs;
+    case "30d":
+      return now - 30 * dayMs;
+    case "all":
+      return 0;
+  }
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -113,7 +113,8 @@ export default defineSchema({
   })
     .index("by_conversation", ["conversationId"])
     .index("by_agent", ["agentId"])
-    .index("by_source", ["source"]),
+    .index("by_source", ["source"])
+    .index("by_created_at", ["createdAt"]),
 
   agentLogs: defineTable({
     agentId: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -108,6 +108,13 @@ export default defineSchema({
     cacheReadTokens: v.number(),
     cacheCreationTokens: v.number(),
     costUsd: v.number(),
+    authMethod: v.optional(
+      v.union(
+        v.literal("api"),
+        v.literal("subscription"),
+        v.literal("unknown"),
+      ),
+    ),
     durationMs: v.number(),
     createdAt: v.number(),
   })
@@ -229,6 +236,22 @@ export default defineSchema({
   settings: defineTable({
     key: v.string(),
     value: v.string(),
+    updatedAt: v.number(),
+  }).index("by_key", ["key"]),
+
+  services: defineTable({
+    // Stable key like "anthropic", "composio", "convex", "other-<name>"
+    key: v.string(),
+    displayName: v.string(),
+    monthlyCostUsd: v.number(),
+    planName: v.optional(v.string()),
+    // Free-form numeric limits (e.g. { tool_executions: 100000, connected_accounts: 10 })
+    planLimits: v.optional(v.string()), // JSON-encoded for flexibility
+    lastFetchAt: v.optional(v.number()),
+    // JSON-encoded usage snapshot from the fetcher
+    usageSnapshot: v.optional(v.string()),
+    notes: v.optional(v.string()),
+    createdAt: v.number(),
     updatedAt: v.number(),
   }).index("by_key", ["key"]),
 });

--- a/convex/services.ts
+++ b/convex/services.ts
@@ -1,0 +1,94 @@
+import { mutation, query } from "./_generated/server.js";
+import { v } from "convex/values";
+
+export const list = query({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db.query("services").collect();
+  },
+});
+
+export const get = query({
+  args: { key: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("services")
+      .withIndex("by_key", (q) => q.eq("key", args.key))
+      .unique();
+  },
+});
+
+export const monthlyTotal = query({
+  args: {},
+  handler: async (ctx) => {
+    const all = await ctx.db.query("services").collect();
+    return all.reduce((sum, s) => sum + s.monthlyCostUsd, 0);
+  },
+});
+
+export const upsert = mutation({
+  args: {
+    key: v.string(),
+    displayName: v.string(),
+    monthlyCostUsd: v.number(),
+    planName: v.optional(v.string()),
+    planLimits: v.optional(v.string()),
+    notes: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("services")
+      .withIndex("by_key", (q) => q.eq("key", args.key))
+      .unique();
+    const now = Date.now();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        displayName: args.displayName,
+        monthlyCostUsd: args.monthlyCostUsd,
+        planName: args.planName,
+        planLimits: args.planLimits,
+        notes: args.notes,
+        updatedAt: now,
+      });
+      return existing._id;
+    }
+    return await ctx.db.insert("services", {
+      ...args,
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
+export const setUsageSnapshot = mutation({
+  args: {
+    key: v.string(),
+    usageSnapshot: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("services")
+      .withIndex("by_key", (q) => q.eq("key", args.key))
+      .unique();
+    if (!existing) return null;
+    await ctx.db.patch(existing._id, {
+      usageSnapshot: args.usageSnapshot,
+      lastFetchAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    return existing._id;
+  },
+});
+
+export const remove = mutation({
+  args: { key: v.string() },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("services")
+      .withIndex("by_key", (q) => q.eq("key", args.key))
+      .unique();
+    if (!existing) return false;
+    await ctx.db.delete(existing._id);
+    return true;
+  },
+});

--- a/convex/usage.ts
+++ b/convex/usage.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { rangeStart, type RangeKey } from "./lib/timeRange.js";
 import { savedFromCacheRead } from "./lib/pricing.js";
+import { detectAnomalies } from "./lib/anomalies.js";
 
 const rangeV = v.union(
   v.literal("today"),
@@ -294,5 +295,21 @@ export const recentRecords = query({
         return true;
       }),
     };
+  },
+});
+
+export const anomalies = query({
+  args: { range: rangeV },
+  handler: async (ctx, args) => {
+    // Always pull a 5-week window; cost_spike needs prior weeks regardless
+    // of the caller's `range`.
+    const fiveWeeksAgo = Date.now() - 5 * 7 * 24 * 60 * 60 * 1000;
+    const start = Math.min(rangeStart(args.range), fiveWeeksAgo);
+    const rows = await ctx.db
+      .query("usageRecords")
+      .withIndex("by_created_at", (q: any) => q.gte("createdAt", start))
+      .order("desc")
+      .take(SCAN_CAP);
+    return detectAnomalies(rows as any, args.range);
   },
 });

--- a/convex/usage.ts
+++ b/convex/usage.ts
@@ -1,0 +1,121 @@
+import { query } from "./_generated/server.js";
+import { v } from "convex/values";
+import { rangeStart, type RangeKey } from "./lib/timeRange.js";
+
+const rangeV = v.union(
+  v.literal("today"),
+  v.literal("7d"),
+  v.literal("30d"),
+  v.literal("all"),
+);
+
+const sourceFilterV = v.optional(
+  v.union(
+    v.literal("dispatcher"),
+    v.literal("execution"),
+    v.literal("extract"),
+    v.literal("consolidation-proposer"),
+    v.literal("consolidation-adversary"),
+    v.literal("consolidation-judge"),
+  ),
+);
+
+// Cap the scan to keep queries bounded as usageRecords grows. Convex's
+// hard collect() limit is 16,384.
+const SCAN_CAP = 10_000;
+
+async function scanRange(
+  ctx: { db: any },
+  range: RangeKey,
+  filter?: { source?: string; conversationId?: string },
+) {
+  const start = rangeStart(range);
+  const all = await ctx.db
+    .query("usageRecords")
+    .withIndex("by_created_at", (q: any) => q.gte("createdAt", start))
+    .order("desc")
+    .take(SCAN_CAP);
+  if (!filter) return all;
+  return all.filter((r: any) => {
+    if (filter.source && r.source !== filter.source) return false;
+    if (filter.conversationId && r.conversationId !== filter.conversationId) return false;
+    return true;
+  });
+}
+
+export const summary = query({
+  args: {
+    range: rangeV,
+    source: sourceFilterV,
+    conversationId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const rows = await scanRange(ctx, args.range, {
+      source: args.source,
+      conversationId: args.conversationId,
+    });
+    let costUsd = 0;
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let cacheReadTokens = 0;
+    let cacheCreationTokens = 0;
+    for (const r of rows) {
+      costUsd += r.costUsd;
+      inputTokens += r.inputTokens;
+      outputTokens += r.outputTokens;
+      cacheReadTokens += r.cacheReadTokens;
+      cacheCreationTokens += r.cacheCreationTokens;
+    }
+    const cachedReadable = cacheReadTokens + inputTokens;
+    const cacheHitRate = cachedReadable > 0 ? cacheReadTokens / cachedReadable : 0;
+    return {
+      costUsd,
+      inputTokens,
+      outputTokens,
+      cacheReadTokens,
+      cacheCreationTokens,
+      callCount: rows.length,
+      cacheHitRate,
+    };
+  },
+});
+
+export const bySource = query({
+  args: { range: rangeV },
+  handler: async (ctx, args) => {
+    const rows = await scanRange(ctx, args.range);
+    const buckets = new Map<
+      string,
+      {
+        source: string;
+        costUsd: number;
+        callCount: number;
+        inputTokens: number;
+        cacheReadTokens: number;
+      }
+    >();
+    for (const r of rows) {
+      const b = buckets.get(r.source) ?? {
+        source: r.source,
+        costUsd: 0,
+        callCount: 0,
+        inputTokens: 0,
+        cacheReadTokens: 0,
+      };
+      b.costUsd += r.costUsd;
+      b.callCount += 1;
+      b.inputTokens += r.inputTokens;
+      b.cacheReadTokens += r.cacheReadTokens;
+      buckets.set(r.source, b);
+    }
+    return [...buckets.values()].map((b) => ({
+      source: b.source,
+      costUsd: b.costUsd,
+      callCount: b.callCount,
+      cacheHitRate:
+        b.cacheReadTokens + b.inputTokens > 0
+          ? b.cacheReadTokens / (b.cacheReadTokens + b.inputTokens)
+          : 0,
+    }));
+  },
+});

--- a/convex/usage.ts
+++ b/convex/usage.ts
@@ -1,6 +1,7 @@
 import { query } from "./_generated/server.js";
 import { v } from "convex/values";
 import { rangeStart, type RangeKey } from "./lib/timeRange.js";
+import { savedFromCacheRead } from "./lib/pricing.js";
 
 const rangeV = v.union(
   v.literal("today"),
@@ -182,5 +183,90 @@ export const byDay = query({
       days.set(key, bucket);
     }
     return [...days.values()].sort((a, b) => a.day.localeCompare(b.day));
+  },
+});
+
+export const cachingStats = query({
+  args: { range: rangeV },
+  handler: async (ctx, args) => {
+    const rows = await scanRange(ctx, args.range);
+    const buckets = new Map<
+      string,
+      {
+        source: string;
+        cacheReadTokens: number;
+        inputTokens: number;
+        savedUsd: number;
+      }
+    >();
+    let totalSavedUsd = 0;
+    for (const r of rows) {
+      const b = buckets.get(r.source) ?? {
+        source: r.source,
+        cacheReadTokens: 0,
+        inputTokens: 0,
+        savedUsd: 0,
+      };
+      b.cacheReadTokens += r.cacheReadTokens;
+      b.inputTokens += r.inputTokens;
+      const saved = savedFromCacheRead(r.model, r.cacheReadTokens);
+      b.savedUsd += saved;
+      totalSavedUsd += saved;
+      buckets.set(r.source, b);
+    }
+
+    // Broken-cache count: dispatcher records with cacheReadTokens=0 whose
+    // immediately-previous dispatcher record on the same conversation was
+    // within 5 minutes.
+    const dispatcherRows = rows
+      .filter((r: any) => r.source === "dispatcher" && r.conversationId)
+      .sort((a: any, b: any) => a.createdAt - b.createdAt);
+    const lastByConv = new Map<string, { createdAt: number }>();
+    let brokenCacheCount = 0;
+    for (const r of dispatcherRows) {
+      const prev = lastByConv.get(r.conversationId!);
+      if (
+        prev &&
+        r.createdAt - prev.createdAt <= 5 * 60 * 1000 &&
+        r.cacheReadTokens === 0
+      ) {
+        brokenCacheCount += 1;
+      }
+      lastByConv.set(r.conversationId!, { createdAt: r.createdAt });
+    }
+
+    return {
+      perSource: [...buckets.values()].map((b) => ({
+        source: b.source,
+        hitRate:
+          b.cacheReadTokens + b.inputTokens > 0
+            ? b.cacheReadTokens / (b.cacheReadTokens + b.inputTokens)
+            : 0,
+        savedUsd: b.savedUsd,
+      })),
+      totalSavedUsd,
+      brokenCacheCount,
+    };
+  },
+});
+
+export const contextSizes = query({
+  args: { conversationId: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? 200;
+    const rows = await ctx.db
+      .query("usageRecords")
+      .withIndex("by_conversation", (q: any) =>
+        q.eq("conversationId", args.conversationId),
+      )
+      .order("asc")
+      .take(limit);
+    return rows.map((r: any) => ({
+      turnId: r.turnId,
+      createdAt: r.createdAt,
+      contextTokens: r.inputTokens + r.cacheReadTokens + r.cacheCreationTokens,
+      costUsd: r.costUsd,
+      source: r.source,
+    }));
   },
 });

--- a/convex/usage.ts
+++ b/convex/usage.ts
@@ -119,3 +119,68 @@ export const bySource = query({
     }));
   },
 });
+
+export const byConversation = query({
+  args: { range: rangeV, limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const rows = await scanRange(ctx, args.range);
+    const limit = args.limit ?? 10;
+    const buckets = new Map<
+      string,
+      { conversationId: string; costUsd: number; callCount: number; lastActivityAt: number }
+    >();
+    for (const r of rows) {
+      if (!r.conversationId) continue;
+      const b = buckets.get(r.conversationId) ?? {
+        conversationId: r.conversationId,
+        costUsd: 0,
+        callCount: 0,
+        lastActivityAt: 0,
+      };
+      b.costUsd += r.costUsd;
+      b.callCount += 1;
+      if (r.createdAt > b.lastActivityAt) b.lastActivityAt = r.createdAt;
+      buckets.set(r.conversationId, b);
+    }
+    return [...buckets.values()]
+      .sort((a, b) => b.costUsd - a.costUsd)
+      .slice(0, limit);
+  },
+});
+
+export const byDay = query({
+  args: { range: rangeV },
+  handler: async (ctx, args) => {
+    const rows = await scanRange(ctx, args.range);
+    const days = new Map<
+      string,
+      {
+        day: string;
+        costUsd: number;
+        costBySource: {
+          dispatcher: number;
+          execution: number;
+          extract: number;
+          consolidation: number;
+        };
+      }
+    >();
+    for (const r of rows) {
+      const d = new Date(r.createdAt);
+      d.setUTCHours(0, 0, 0, 0);
+      const key = d.toISOString().slice(0, 10);
+      const bucket = days.get(key) ?? {
+        day: key,
+        costUsd: 0,
+        costBySource: { dispatcher: 0, execution: 0, extract: 0, consolidation: 0 },
+      };
+      bucket.costUsd += r.costUsd;
+      const srcKey: keyof typeof bucket.costBySource = r.source.startsWith("consolidation")
+        ? "consolidation"
+        : (r.source as "dispatcher" | "execution" | "extract");
+      bucket.costBySource[srcKey] += r.costUsd;
+      days.set(key, bucket);
+    }
+    return [...days.values()].sort((a, b) => a.day.localeCompare(b.day));
+  },
+});

--- a/convex/usage.ts
+++ b/convex/usage.ts
@@ -1,5 +1,6 @@
 import { query } from "./_generated/server.js";
 import { v } from "convex/values";
+import { paginationOptsValidator } from "convex/server";
 import { rangeStart, type RangeKey } from "./lib/timeRange.js";
 import { savedFromCacheRead } from "./lib/pricing.js";
 
@@ -268,5 +269,30 @@ export const contextSizes = query({
       costUsd: r.costUsd,
       source: r.source,
     }));
+  },
+});
+
+export const recentRecords = query({
+  args: {
+    paginationOpts: paginationOptsValidator,
+    source: sourceFilterV,
+    conversationId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query("usageRecords")
+      .withIndex("by_created_at")
+      .order("desc")
+      .paginate(args.paginationOpts);
+    if (!args.source && !args.conversationId) return result;
+    return {
+      ...result,
+      page: result.page.filter((r: any) => {
+        if (args.source && r.source !== args.source) return false;
+        if (args.conversationId && r.conversationId !== args.conversationId)
+          return false;
+        return true;
+      }),
+    };
   },
 });

--- a/convex/usageRecords.ts
+++ b/convex/usageRecords.ts
@@ -23,6 +23,7 @@ export const record = mutation({
     cacheReadTokens: v.number(),
     cacheCreationTokens: v.number(),
     costUsd: v.number(),
+    authMethod: v.optional(v.union(v.literal("api"), v.literal("subscription"), v.literal("unknown"))),
     durationMs: v.number(),
   },
   handler: async (ctx, args) => {

--- a/debug/src/App.tsx
+++ b/debug/src/App.tsx
@@ -9,6 +9,7 @@ import {
   Link04Icon,
   DashboardSquare01Icon,
   ArrowShrink02Icon,
+  MoneyBag02Icon,
 } from "@hugeicons/core-free-icons";
 import { api } from "../../convex/_generated/api.js";
 import { useSocket } from "./lib/useSocket.js";
@@ -19,9 +20,11 @@ import { MemoryPanel } from "./components/MemoryPanel.js";
 import { EventsPanel } from "./components/EventsPanel.js";
 import { ConnectionsPanel } from "./components/ConnectionsPanel.js";
 import { ConsolidationPanel } from "./components/ConsolidationPanel.js";
+import { ConsumoPanel } from "./components/ConsumoPanel.js";
 
 type View =
   | "dashboard"
+  | "consumo"
   | "agents"
   | "automations"
   | "memory"
@@ -33,6 +36,7 @@ type Theme = "dark" | "light";
 
 const NAV_ICONS: Record<View, any> = {
   dashboard: DashboardSquare01Icon,
+  consumo: MoneyBag02Icon,
   agents: MachineRobotIcon,
   automations: WorkflowCircle03Icon,
   memory: AiBrain02Icon,
@@ -43,6 +47,7 @@ const NAV_ICONS: Record<View, any> = {
 
 const NAV: { id: View; label: string }[] = [
   { id: "dashboard", label: "Dashboard" },
+  { id: "consumo", label: "Consumo" },
   { id: "agents", label: "Agents" },
   { id: "automations", label: "Automations" },
   { id: "memory", label: "Memory" },
@@ -218,6 +223,7 @@ export function App() {
         <main className="flex-1 min-w-0 overflow-hidden debug-scroll">
           <div className="h-full overflow-auto debug-scroll p-5 fade-in">
             {view === "dashboard" && <DashboardPanel isDark={isDark} />}
+            {view === "consumo" && <ConsumoPanel isDark={isDark} />}
             {view === "agents" && <AgentsPanel isDark={isDark} />}
             {view === "automations" && <AutomationsPanel isDark={isDark} />}
             {view === "memory" && <MemoryPanel isDark={isDark} />}

--- a/debug/src/components/ConsumoPanel.tsx
+++ b/debug/src/components/ConsumoPanel.tsx
@@ -8,6 +8,12 @@ import { TopConversationsList } from "./consumo/TopConversationsList.js";
 import { DrillDownTable } from "./consumo/DrillDownTable.js";
 import { ConversationDrilldown } from "./consumo/ConversationDrilldown.js";
 import { AnomalyBadge } from "./consumo/AnomalyBadge.js";
+import { ServicesPanel } from "./consumo/ServicesPanel.js";
+import { ClaudeBreakEvenCard } from "./consumo/ClaudeBreakEvenCard.js";
+import { getAdminToken } from "../lib/adminAuth.js";
+
+// Same-origin via vite proxy: /api/* is rewritten to / on the boop server.
+const SERVER_ORIGIN = "/api";
 
 type Range = "today" | "7d" | "30d" | "all";
 
@@ -32,6 +38,14 @@ export function ConsumoPanel({ isDark }: Props) {
   const top = useQuery(api.usage.byConversation, { range, limit: 10 });
   const caching = useQuery(api.usage.cachingStats, { range });
   const anomalies = useQuery(api.usage.anomalies, { range });
+
+  const services = useQuery(api.services.list, {});
+  const fixedMonthly = useQuery(api.services.monthlyTotal, {});
+  // Anthropic-specific service for break-even card
+  const anthropicService = services?.find((s: any) => s.key === "anthropic");
+  // Summary scoped to the current month for break-even comparison
+  const monthSummary = useQuery(api.usage.summary, { range: "30d" });
+  const adminToken = getAdminToken();
 
   // Mark bySource as intentionally referenced to keep the warm cache without TS6133.
   void bySource;
@@ -77,7 +91,24 @@ export function ConsumoPanel({ isDark }: Props) {
         </div>
       </div>
 
-      <KpiCards summary={summary} top={top?.[0]} isDark={isDark} />
+      <ServicesPanel
+        isDark={isDark}
+        serverOrigin={SERVER_ORIGIN}
+        adminToken={adminToken}
+      />
+
+      <ClaudeBreakEvenCard
+        anthropicService={anthropicService}
+        monthSummary={monthSummary}
+        isDark={isDark}
+      />
+
+      <KpiCards
+        summary={summary}
+        top={top?.[0]}
+        fixedMonthlyUsd={fixedMonthly}
+        isDark={isDark}
+      />
 
       {anomalies && anomalies.length > 0 && (
         <AnomalyBadge anomalies={anomalies} isDark={isDark} />

--- a/debug/src/components/ConsumoPanel.tsx
+++ b/debug/src/components/ConsumoPanel.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api.js";
+import { KpiCards } from "./consumo/KpiCards.js";
+import { DailyCostChart } from "./consumo/DailyCostChart.js";
+import { CachingPanel } from "./consumo/CachingPanel.js";
+import { TopConversationsList } from "./consumo/TopConversationsList.js";
+import { DrillDownTable } from "./consumo/DrillDownTable.js";
+import { ConversationDrilldown } from "./consumo/ConversationDrilldown.js";
+import { AnomalyBadge } from "./consumo/AnomalyBadge.js";
+
+type Range = "today" | "7d" | "30d" | "all";
+
+const RANGE_LABELS: Record<Range, string> = {
+  today: "Hoje",
+  "7d": "7d",
+  "30d": "30d",
+  all: "Tudo",
+};
+
+interface Props {
+  isDark: boolean;
+}
+
+export function ConsumoPanel({ isDark }: Props) {
+  const [range, setRange] = useState<Range>("7d");
+  const [selectedConv, setSelectedConv] = useState<string | null>(null);
+
+  const summary = useQuery(api.usage.summary, { range });
+  const bySource = useQuery(api.usage.bySource, { range });
+  const byDay = useQuery(api.usage.byDay, { range });
+  const top = useQuery(api.usage.byConversation, { range, limit: 10 });
+  const caching = useQuery(api.usage.cachingStats, { range });
+  const anomalies = useQuery(api.usage.anomalies, { range });
+
+  // Mark bySource as intentionally referenced to keep the warm cache without TS6133.
+  void bySource;
+
+  const tabBase = "px-3 py-1 text-xs rounded-md transition-colors mono";
+  const tabActive = isDark
+    ? "bg-slate-800 text-slate-100 font-semibold"
+    : "bg-slate-200 text-slate-900 font-semibold";
+  const tabIdle = isDark
+    ? "text-slate-500 hover:text-slate-300"
+    : "text-slate-500 hover:text-slate-700";
+
+  if (selectedConv) {
+    return (
+      <ConversationDrilldown
+        conversationId={selectedConv}
+        isDark={isDark}
+        onBack={() => setSelectedConv(null)}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex gap-1">
+          {(Object.keys(RANGE_LABELS) as Range[]).map((r) => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`${tabBase} ${range === r ? tabActive : tabIdle}`}
+            >
+              {RANGE_LABELS[r]}
+            </button>
+          ))}
+        </div>
+        <div className="text-xs">
+          {anomalies && anomalies.length > 0 && (
+            <span className={isDark ? "text-rose-400" : "text-rose-600"}>
+              🔴 {anomalies.length} alerta{anomalies.length === 1 ? "" : "s"}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <KpiCards summary={summary} top={top?.[0]} isDark={isDark} />
+
+      {anomalies && anomalies.length > 0 && (
+        <AnomalyBadge anomalies={anomalies} isDark={isDark} />
+      )}
+
+      <DailyCostChart data={byDay} isDark={isDark} />
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <CachingPanel stats={caching} isDark={isDark} />
+        <TopConversationsList
+          data={top}
+          isDark={isDark}
+          onSelect={setSelectedConv}
+        />
+      </div>
+
+      <DrillDownTable isDark={isDark} />
+    </div>
+  );
+}

--- a/debug/src/components/consumo/AnomalyBadge.tsx
+++ b/debug/src/components/consumo/AnomalyBadge.tsx
@@ -1,0 +1,40 @@
+interface Anomaly {
+  kind: "cost_spike" | "low_cache_hit" | "broken_cache" | "giant_turn";
+  severity: "low" | "medium" | "high";
+  message: string;
+}
+
+interface Props {
+  anomalies: Anomaly[];
+  isDark: boolean;
+}
+
+const SEVERITY_COLOR: Record<string, { dark: string; light: string }> = {
+  high: { dark: "bg-rose-900/40 text-rose-300 border-rose-700/50", light: "bg-rose-100 text-rose-700 border-rose-300" },
+  medium: { dark: "bg-amber-900/40 text-amber-300 border-amber-700/50", light: "bg-amber-100 text-amber-700 border-amber-300" },
+  low: { dark: "bg-slate-800 text-slate-400 border-slate-700", light: "bg-slate-100 text-slate-600 border-slate-300" },
+};
+
+export function AnomalyBadge({ anomalies, isDark }: Props) {
+  if (anomalies.length === 0) return null;
+  const counts = { high: 0, medium: 0, low: 0 };
+  for (const a of anomalies) counts[a.severity] += 1;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {anomalies.map((a, i) => {
+        const c = SEVERITY_COLOR[a.severity];
+        const cls = isDark ? c.dark : c.light;
+        return (
+          <div
+            key={i}
+            className={`text-xs px-2.5 py-1.5 rounded border ${cls}`}
+            title={a.kind}
+          >
+            {a.message}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/debug/src/components/consumo/CachingPanel.tsx
+++ b/debug/src/components/consumo/CachingPanel.tsx
@@ -1,0 +1,84 @@
+interface SourceStat {
+  source: string;
+  hitRate: number;
+  savedUsd: number;
+}
+
+interface CachingStats {
+  perSource: SourceStat[];
+  totalSavedUsd: number;
+  brokenCacheCount: number;
+}
+
+interface Props {
+  stats: CachingStats | undefined;
+  isDark: boolean;
+}
+
+function fmtPct(v: number): string {
+  return `${(v * 100).toFixed(0)}%`;
+}
+
+export function CachingPanel({ stats, isDark }: Props) {
+  const cardCls = isDark
+    ? "border-slate-800 bg-slate-900/40"
+    : "border-slate-200 bg-white";
+  const labelCls = isDark ? "text-slate-400" : "text-slate-600";
+  const titleCls = isDark ? "text-slate-300" : "text-slate-700";
+
+  if (!stats) {
+    return (
+      <div className={`border rounded-lg p-4 ${cardCls}`}>
+        <div className={`text-sm font-semibold ${titleCls}`}>Cache health</div>
+        <div className={`text-xs mt-2 ${labelCls}`}>carregando...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`border rounded-lg p-4 ${cardCls}`}>
+      <div className="flex items-baseline justify-between mb-3">
+        <div className={`text-sm font-semibold ${titleCls}`}>Cache health</div>
+        <div className={`text-xs mono ${labelCls}`}>
+          economizou ${stats.totalSavedUsd.toFixed(2)}
+        </div>
+      </div>
+      <div className="space-y-2">
+        {stats.perSource.length === 0 && (
+          <div className={`text-xs ${labelCls}`}>Sem dados de cache no período.</div>
+        )}
+        {stats.perSource.map((s) => {
+          const widthPct = Math.round(s.hitRate * 100);
+          const barColor =
+            s.hitRate >= 0.7
+              ? "bg-emerald-500"
+              : s.hitRate >= 0.5
+                ? "bg-amber-500"
+                : "bg-rose-500";
+          return (
+            <div key={s.source} className="grid grid-cols-[120px_1fr_80px] items-center gap-2 text-xs">
+              <span className={`mono ${labelCls}`}>{s.source}</span>
+              <div className={`h-2 rounded ${isDark ? "bg-slate-800" : "bg-slate-200"}`}>
+                <div className={`h-full rounded ${barColor}`} style={{ width: `${widthPct}%` }} />
+              </div>
+              <span className={`mono ${labelCls} text-right`}>
+                {fmtPct(s.hitRate)} · ${s.savedUsd.toFixed(2)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      {stats.brokenCacheCount > 0 && (
+        <div
+          className={`mt-3 text-xs px-2 py-1.5 rounded ${
+            isDark
+              ? "bg-amber-900/30 text-amber-300 border border-amber-700/40"
+              : "bg-amber-50 text-amber-800 border border-amber-200"
+          }`}
+        >
+          ⚠️ {stats.brokenCacheCount} turnos do dispatcher com cache_read=0 dentro do TTL
+        </div>
+      )}
+    </div>
+  );
+}

--- a/debug/src/components/consumo/ClaudeBreakEvenCard.tsx
+++ b/debug/src/components/consumo/ClaudeBreakEvenCard.tsx
@@ -1,0 +1,97 @@
+interface AnthropicService {
+  monthlyCostUsd: number;
+  planName?: string;
+}
+
+interface MonthSummary {
+  costUsd: number;
+  callCount: number;
+}
+
+interface Props {
+  anthropicService: AnthropicService | undefined;
+  monthSummary: MonthSummary | undefined;
+  isDark: boolean;
+}
+
+function fmtUsd(v: number): string {
+  return `$${v.toFixed(2)}`;
+}
+
+export function ClaudeBreakEvenCard({ anthropicService, monthSummary, isDark }: Props) {
+  if (!anthropicService || anthropicService.monthlyCostUsd === 0) return null;
+
+  const cardCls = isDark
+    ? "border-slate-800 bg-slate-900/40"
+    : "border-slate-200 bg-white";
+  const titleCls = isDark ? "text-slate-300" : "text-slate-700";
+  const labelCls = isDark ? "text-slate-500" : "text-slate-500";
+  const valueCls = isDark ? "text-slate-100" : "text-slate-900";
+
+  const equivalent = monthSummary?.costUsd ?? 0;
+  const sub = anthropicService.monthlyCostUsd;
+  const utilizationPct = sub > 0 ? Math.min(100, Math.round((equivalent / sub) * 100)) : 0;
+  const overage = equivalent - sub;
+  const subWorthIt = equivalent >= sub;
+
+  const barColor =
+    utilizationPct >= 100
+      ? "bg-emerald-500"
+      : utilizationPct >= 50
+        ? "bg-sky-500"
+        : "bg-slate-500";
+
+  return (
+    <div className={`border rounded-lg p-4 ${cardCls}`}>
+      <div className="flex items-baseline justify-between mb-3">
+        <div className={`text-sm font-semibold ${titleCls}`}>
+          Claude — sub vs API equivalente (mês corrente)
+        </div>
+        <div className={`text-xs mono ${labelCls}`}>
+          plano: {anthropicService.planName ?? "—"}
+        </div>
+      </div>
+      <div className="grid grid-cols-3 gap-4 mb-3">
+        <div>
+          <div className={`text-[11px] uppercase tracking-wide ${labelCls}`}>
+            Sub paga
+          </div>
+          <div className={`text-xl font-bold mono ${valueCls}`}>{fmtUsd(sub)}</div>
+        </div>
+        <div>
+          <div className={`text-[11px] uppercase tracking-wide ${labelCls}`}>
+            Equivalente API
+          </div>
+          <div className={`text-xl font-bold mono ${valueCls}`}>
+            {fmtUsd(equivalent)}
+          </div>
+        </div>
+        <div>
+          <div className={`text-[11px] uppercase tracking-wide ${labelCls}`}>
+            {subWorthIt ? "Economia" : "Falta pra break-even"}
+          </div>
+          <div
+            className={`text-xl font-bold mono ${
+              subWorthIt
+                ? isDark
+                  ? "text-emerald-400"
+                  : "text-emerald-600"
+                : valueCls
+            }`}
+          >
+            {fmtUsd(Math.abs(overage))}
+          </div>
+        </div>
+      </div>
+      <div className={`h-2 rounded ${isDark ? "bg-slate-800" : "bg-slate-200"} overflow-hidden`}>
+        <div
+          className={`h-full ${barColor}`}
+          style={{ width: `${utilizationPct}%` }}
+        />
+      </div>
+      <div className={`text-xs mt-1.5 ${labelCls}`}>
+        {utilizationPct}% do valor da sub usado em equivalente API · {monthSummary?.callCount ?? 0} chamadas
+      </div>
+    </div>
+  );
+}

--- a/debug/src/components/consumo/ConversationDrilldown.tsx
+++ b/debug/src/components/consumo/ConversationDrilldown.tsx
@@ -1,0 +1,138 @@
+import { useQuery } from "convex/react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ResponsiveContainer,
+} from "recharts";
+import { api } from "../../../../convex/_generated/api.js";
+import { DrillDownTable } from "./DrillDownTable.js";
+
+interface Props {
+  conversationId: string;
+  isDark: boolean;
+  onBack: () => void;
+}
+
+const SONNET_CTX_LIMIT = 200_000;
+
+function fmtTime(ms: number): string {
+  return new Date(ms).toLocaleTimeString("pt-BR", { hour12: false });
+}
+
+export function ConversationDrilldown({ conversationId, isDark, onBack }: Props) {
+  const points = useQuery(api.usage.contextSizes, {
+    conversationId,
+    limit: 200,
+  });
+
+  const cardCls = isDark
+    ? "border-slate-800 bg-slate-900/40"
+    : "border-slate-200 bg-white";
+  const titleCls = isDark ? "text-slate-300" : "text-slate-700";
+  const labelCls = isDark ? "text-slate-500" : "text-slate-500";
+
+  let cumulative = 0;
+  const chartData = (points ?? []).map((p: any) => {
+    cumulative += p.costUsd;
+    return {
+      time: fmtTime(p.createdAt),
+      contextTokens: p.contextTokens,
+      costUsd: p.costUsd,
+      cumulativeUsd: cumulative,
+    };
+  });
+
+  const totalCost = chartData.length ? chartData[chartData.length - 1].cumulativeUsd : 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <button
+          onClick={onBack}
+          className={`text-xs px-2.5 py-1 rounded border ${
+            isDark
+              ? "border-slate-700 text-slate-400 hover:bg-slate-800/40"
+              : "border-slate-300 text-slate-600 hover:bg-slate-50"
+          }`}
+        >
+          ← voltar
+        </button>
+        <span className={`mono text-sm ${titleCls}`}>{conversationId}</span>
+        <span className={`mono text-xs ${labelCls}`}>
+          total ${totalCost.toFixed(2)} · {chartData.length} chamadas
+        </span>
+      </div>
+
+      <div className={`border rounded-lg p-4 ${cardCls}`}>
+        <div className={`text-sm font-semibold mb-2 ${titleCls}`}>
+          Tamanho do contexto por turno
+        </div>
+        <div style={{ width: "100%", height: 220 }}>
+          <ResponsiveContainer>
+            <LineChart data={chartData}>
+              <CartesianGrid stroke={isDark ? "#1e293b" : "#e2e8f0"} strokeDasharray="3 3" />
+              <XAxis dataKey="time" stroke={isDark ? "#64748b" : "#94a3b8"} fontSize={11} />
+              <YAxis
+                stroke={isDark ? "#64748b" : "#94a3b8"}
+                fontSize={11}
+                tickFormatter={(v) => `${(v / 1000).toFixed(0)}k`}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: isDark ? "#0f172a" : "#fff",
+                  border: `1px solid ${isDark ? "#334155" : "#e2e8f0"}`,
+                  borderRadius: 6,
+                  fontSize: 12,
+                }}
+                formatter={(v: any) => `${Number(v).toLocaleString()} tokens`}
+              />
+              <ReferenceLine
+                y={SONNET_CTX_LIMIT}
+                stroke="#f43f5e"
+                strokeDasharray="4 4"
+                label={{ value: "limite Sonnet (200k)", fill: "#f43f5e", fontSize: 10 }}
+              />
+              <Line type="monotone" dataKey="contextTokens" stroke="#3b82f6" dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      <div className={`border rounded-lg p-4 ${cardCls}`}>
+        <div className={`text-sm font-semibold mb-2 ${titleCls}`}>
+          Custo cumulativo
+        </div>
+        <div style={{ width: "100%", height: 180 }}>
+          <ResponsiveContainer>
+            <LineChart data={chartData}>
+              <CartesianGrid stroke={isDark ? "#1e293b" : "#e2e8f0"} strokeDasharray="3 3" />
+              <XAxis dataKey="time" stroke={isDark ? "#64748b" : "#94a3b8"} fontSize={11} />
+              <YAxis
+                stroke={isDark ? "#64748b" : "#94a3b8"}
+                fontSize={11}
+                tickFormatter={(v) => `$${v.toFixed(2)}`}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: isDark ? "#0f172a" : "#fff",
+                  border: `1px solid ${isDark ? "#334155" : "#e2e8f0"}`,
+                  borderRadius: 6,
+                  fontSize: 12,
+                }}
+                formatter={(v: any) => `$${Number(v).toFixed(4)}`}
+              />
+              <Line type="monotone" dataKey="cumulativeUsd" stroke="#10b981" dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      <DrillDownTable isDark={isDark} conversationId={conversationId} />
+    </div>
+  );
+}

--- a/debug/src/components/consumo/DailyCostChart.tsx
+++ b/debug/src/components/consumo/DailyCostChart.tsx
@@ -1,0 +1,81 @@
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+
+interface DayPoint {
+  day: string;
+  costUsd: number;
+  costBySource: {
+    dispatcher: number;
+    execution: number;
+    extract: number;
+    consolidation: number;
+  };
+}
+
+interface Props {
+  data: DayPoint[] | undefined;
+  isDark: boolean;
+}
+
+const COLORS = {
+  dispatcher: "#3b82f6", // blue
+  execution: "#10b981", // emerald
+  extract: "#a855f7", // purple
+  consolidation: "#f59e0b", // amber
+};
+
+export function DailyCostChart({ data, isDark }: Props) {
+  const cardCls = isDark
+    ? "border-slate-800 bg-slate-900/40"
+    : "border-slate-200 bg-white";
+  const titleCls = isDark ? "text-slate-300" : "text-slate-700";
+
+  const chartData = (data ?? []).map((d) => ({
+    day: d.day.slice(5), // MM-DD
+    dispatcher: d.costBySource.dispatcher,
+    execution: d.costBySource.execution,
+    extract: d.costBySource.extract,
+    consolidation: d.costBySource.consolidation,
+  }));
+
+  return (
+    <div className={`border rounded-lg p-4 ${cardCls}`}>
+      <div className={`text-sm font-semibold mb-3 ${titleCls}`}>Custo diário</div>
+      <div style={{ width: "100%", height: 220 }}>
+        <ResponsiveContainer>
+          <AreaChart data={chartData}>
+            <CartesianGrid stroke={isDark ? "#1e293b" : "#e2e8f0"} strokeDasharray="3 3" />
+            <XAxis dataKey="day" stroke={isDark ? "#64748b" : "#94a3b8"} fontSize={11} />
+            <YAxis
+              stroke={isDark ? "#64748b" : "#94a3b8"}
+              fontSize={11}
+              tickFormatter={(v) => `$${v.toFixed(2)}`}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: isDark ? "#0f172a" : "#fff",
+                border: `1px solid ${isDark ? "#334155" : "#e2e8f0"}`,
+                borderRadius: 6,
+                fontSize: 12,
+              }}
+              formatter={(v: any) => `$${Number(v).toFixed(4)}`}
+            />
+            <Legend wrapperStyle={{ fontSize: 11 }} />
+            <Area type="monotone" dataKey="dispatcher" stackId="1" stroke={COLORS.dispatcher} fill={COLORS.dispatcher} />
+            <Area type="monotone" dataKey="execution" stackId="1" stroke={COLORS.execution} fill={COLORS.execution} />
+            <Area type="monotone" dataKey="extract" stackId="1" stroke={COLORS.extract} fill={COLORS.extract} />
+            <Area type="monotone" dataKey="consolidation" stackId="1" stroke={COLORS.consolidation} fill={COLORS.consolidation} />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/debug/src/components/consumo/DrillDownTable.tsx
+++ b/debug/src/components/consumo/DrillDownTable.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import { usePaginatedQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api.js";
+
+interface Props {
+  isDark: boolean;
+  conversationId?: string;
+}
+
+const SOURCE_OPTIONS = [
+  "all",
+  "dispatcher",
+  "execution",
+  "extract",
+  "consolidation-proposer",
+  "consolidation-adversary",
+  "consolidation-judge",
+] as const;
+
+type SourceOpt = (typeof SOURCE_OPTIONS)[number];
+
+function fmt(v: number): string {
+  if (v >= 1000) return `${(v / 1000).toFixed(1)}k`;
+  return String(v);
+}
+
+function fmtTime(ms: number): string {
+  return new Date(ms).toLocaleString("pt-BR", { hour12: false });
+}
+
+export function DrillDownTable({ isDark, conversationId }: Props) {
+  const [source, setSource] = useState<SourceOpt>("all");
+  const { results, status, loadMore } = usePaginatedQuery(
+    api.usage.recentRecords,
+    {
+      source: source === "all" ? undefined : source,
+      conversationId,
+    },
+    { initialNumItems: 50 },
+  );
+
+  const cardCls = isDark
+    ? "border-slate-800 bg-slate-900/40"
+    : "border-slate-200 bg-white";
+  const titleCls = isDark ? "text-slate-300" : "text-slate-700";
+  const headCls = isDark ? "text-slate-500" : "text-slate-500";
+  const rowCls = isDark
+    ? "border-slate-800 hover:bg-slate-800/30"
+    : "border-slate-100 hover:bg-slate-50";
+  const cellCls = isDark ? "text-slate-300" : "text-slate-700";
+  const selectCls = isDark
+    ? "bg-slate-900 border-slate-700 text-slate-300"
+    : "bg-white border-slate-300 text-slate-700";
+
+  return (
+    <div className={`border rounded-lg p-4 ${cardCls}`}>
+      <div className="flex items-center justify-between mb-3">
+        <div className={`text-sm font-semibold ${titleCls}`}>Drill-down</div>
+        <select
+          value={source}
+          onChange={(e) => setSource(e.target.value as SourceOpt)}
+          className={`text-xs border rounded px-2 py-1 ${selectCls}`}
+        >
+          {SOURCE_OPTIONS.map((o) => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="overflow-auto max-h-[420px]">
+        <table className="w-full text-xs">
+          <thead className={`text-[11px] uppercase tracking-wide ${headCls}`}>
+            <tr>
+              <th className="text-left p-1.5">timestamp</th>
+              <th className="text-left p-1.5">source</th>
+              <th className="text-left p-1.5">conv</th>
+              <th className="text-right p-1.5">in/out</th>
+              <th className="text-right p-1.5">cache r/w</th>
+              <th className="text-right p-1.5">ctx</th>
+              <th className="text-right p-1.5">cost</th>
+              <th className="text-right p-1.5">ms</th>
+            </tr>
+          </thead>
+          <tbody>
+            {results.map((r: any) => {
+              const ctx = r.inputTokens + r.cacheReadTokens + r.cacheCreationTokens;
+              return (
+                <tr key={r._id} className={`border-t ${rowCls}`}>
+                  <td className={`p-1.5 mono ${cellCls}`}>{fmtTime(r.createdAt)}</td>
+                  <td className={`p-1.5 mono ${cellCls}`}>{r.source}</td>
+                  <td className={`p-1.5 mono truncate max-w-[120px] ${cellCls}`}>
+                    {r.conversationId ?? "—"}
+                  </td>
+                  <td className={`p-1.5 mono text-right ${cellCls}`}>
+                    {fmt(r.inputTokens)}/{fmt(r.outputTokens)}
+                  </td>
+                  <td className={`p-1.5 mono text-right ${cellCls}`}>
+                    {fmt(r.cacheReadTokens)}/{fmt(r.cacheCreationTokens)}
+                  </td>
+                  <td className={`p-1.5 mono text-right ${cellCls}`}>{fmt(ctx)}</td>
+                  <td className={`p-1.5 mono text-right ${cellCls}`}>
+                    ${r.costUsd.toFixed(4)}
+                  </td>
+                  <td className={`p-1.5 mono text-right ${cellCls}`}>{r.durationMs}</td>
+                </tr>
+              );
+            })}
+            {results.length === 0 && (
+              <tr>
+                <td colSpan={8} className={`p-3 text-center ${headCls}`}>
+                  Sem registros.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      {status === "CanLoadMore" && (
+        <button
+          onClick={() => loadMore(50)}
+          className={`mt-2 w-full text-xs py-1.5 rounded border ${
+            isDark
+              ? "border-slate-700 text-slate-400 hover:bg-slate-800/40"
+              : "border-slate-300 text-slate-600 hover:bg-slate-50"
+          }`}
+        >
+          Carregar mais
+        </button>
+      )}
+    </div>
+  );
+}

--- a/debug/src/components/consumo/KpiCards.tsx
+++ b/debug/src/components/consumo/KpiCards.tsx
@@ -1,0 +1,83 @@
+interface Summary {
+  costUsd: number;
+  callCount: number;
+  cacheHitRate: number;
+}
+
+interface TopConversation {
+  conversationId: string;
+  costUsd: number;
+  callCount: number;
+}
+
+interface Props {
+  summary: Summary | undefined;
+  top: TopConversation | undefined;
+  isDark: boolean;
+}
+
+function fmtUsd(v: number): string {
+  return `$${v.toFixed(2)}`;
+}
+
+function fmtPct(v: number): string {
+  return `${(v * 100).toFixed(0)}%`;
+}
+
+function shortConv(id: string): string {
+  if (id.startsWith("telegram:")) return id.slice(9);
+  return id.length > 12 ? id.slice(0, 12) + "..." : id;
+}
+
+export function KpiCards({ summary, top, isDark }: Props) {
+  const cardCls = isDark
+    ? "border-slate-800 bg-slate-900/40"
+    : "border-slate-200 bg-white";
+  const labelCls = isDark ? "text-slate-500" : "text-slate-500";
+  const valueCls = isDark ? "text-slate-100" : "text-slate-900";
+
+  const cards = [
+    {
+      label: "Custo total",
+      value: summary ? fmtUsd(summary.costUsd) : "—",
+      sub: summary ? `${summary.callCount} chamadas` : "carregando...",
+    },
+    {
+      label: "Cache hit",
+      value: summary ? fmtPct(summary.cacheHitRate) : "—",
+      sub: "input tokens cacheados",
+    },
+    {
+      label: "$ / chamada",
+      value:
+        summary && summary.callCount > 0
+          ? fmtUsd(summary.costUsd / summary.callCount)
+          : "—",
+      sub: "média no período",
+    },
+    {
+      label: "Top conversa",
+      value: top ? fmtUsd(top.costUsd) : "—",
+      sub: top ? shortConv(top.conversationId) : "sem dados",
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      {cards.map((c) => (
+        <div
+          key={c.label}
+          className={`border rounded-lg p-4 ${cardCls}`}
+        >
+          <div className={`text-[11px] uppercase tracking-wide ${labelCls}`}>
+            {c.label}
+          </div>
+          <div className={`text-2xl font-bold mono mt-1 ${valueCls}`}>
+            {c.value}
+          </div>
+          <div className={`text-xs ${labelCls} mt-1`}>{c.sub}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/debug/src/components/consumo/KpiCards.tsx
+++ b/debug/src/components/consumo/KpiCards.tsx
@@ -13,6 +13,7 @@ interface TopConversation {
 interface Props {
   summary: Summary | undefined;
   top: TopConversation | undefined;
+  fixedMonthlyUsd: number | undefined;
   isDark: boolean;
 }
 
@@ -29,7 +30,7 @@ function shortConv(id: string): string {
   return id.length > 12 ? id.slice(0, 12) + "..." : id;
 }
 
-export function KpiCards({ summary, top, isDark }: Props) {
+export function KpiCards({ summary, top, fixedMonthlyUsd, isDark }: Props) {
   const cardCls = isDark
     ? "border-slate-800 bg-slate-900/40"
     : "border-slate-200 bg-white";
@@ -60,10 +61,15 @@ export function KpiCards({ summary, top, isDark }: Props) {
       value: top ? fmtUsd(top.costUsd) : "—",
       sub: top ? shortConv(top.conversationId) : "sem dados",
     },
+    {
+      label: "Custos fixos / mês",
+      value: fixedMonthlyUsd !== undefined ? fmtUsd(fixedMonthlyUsd) : "—",
+      sub: "subscriptions cadastradas",
+    },
   ];
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
       {cards.map((c) => (
         <div
           key={c.label}

--- a/debug/src/components/consumo/ServicesPanel.tsx
+++ b/debug/src/components/consumo/ServicesPanel.tsx
@@ -1,0 +1,358 @@
+import { useState } from "react";
+import { useQuery } from "convex/react";
+import { api } from "../../../../convex/_generated/api.js";
+
+interface Service {
+  _id: string;
+  key: string;
+  displayName: string;
+  monthlyCostUsd: number;
+  planName?: string;
+  planLimits?: string;
+  lastFetchAt?: number;
+  usageSnapshot?: string;
+  notes?: string;
+}
+
+interface Props {
+  isDark: boolean;
+  /** Origin of the boop server, e.g. "http://localhost:3456" or "/api" for vite proxy. */
+  serverOrigin: string;
+  /** Admin token for the boop server (used to call /services routes). */
+  adminToken: string;
+}
+
+function fmtUsd(v: number): string {
+  return `$${v.toFixed(2)}`;
+}
+
+function fmtAge(ms?: number): string {
+  if (!ms) return "nunca";
+  const sec = Math.floor((Date.now() - ms) / 1000);
+  if (sec < 60) return `${sec}s atrás`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m atrás`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h atrás`;
+  return `${Math.floor(hr / 24)}d atrás`;
+}
+
+export function ServicesPanel({ isDark, serverOrigin, adminToken }: Props) {
+  const services = useQuery(api.services.list, {});
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const cardCls = isDark
+    ? "border-slate-800 bg-slate-900/40"
+    : "border-slate-200 bg-white";
+  const titleCls = isDark ? "text-slate-300" : "text-slate-700";
+  const labelCls = isDark ? "text-slate-500" : "text-slate-500";
+  const subCls = isDark ? "text-slate-400" : "text-slate-600";
+  const buttonCls = isDark
+    ? "border-slate-700 text-slate-400 hover:bg-slate-800/40"
+    : "border-slate-300 text-slate-600 hover:bg-slate-50";
+
+  async function refresh(key: string) {
+    setRefreshing(key);
+    setError(null);
+    try {
+      const r = await fetch(`${serverOrigin}/services/${key}/refresh`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${adminToken}` },
+      });
+      if (!r.ok) {
+        const body = await r.json().catch(() => ({}));
+        throw new Error(body?.error ?? `HTTP ${r.status}`);
+      }
+    } catch (err) {
+      setError(`${key}: ${(err as Error).message}`);
+    } finally {
+      setRefreshing(null);
+    }
+  }
+
+  return (
+    <div className={`border rounded-lg p-4 ${cardCls}`}>
+      <div className="flex items-center justify-between mb-3">
+        <div className={`text-sm font-semibold ${titleCls}`}>Serviços</div>
+      </div>
+      {!services && <div className={`text-xs ${labelCls}`}>carregando...</div>}
+      {services && services.length === 0 && (
+        <div className={`text-xs ${labelCls}`}>Nenhum serviço cadastrado.</div>
+      )}
+      {error && (
+        <div
+          className={`mb-2 text-xs px-2 py-1 rounded border ${
+            isDark
+              ? "border-rose-700/50 bg-rose-900/30 text-rose-300"
+              : "border-rose-300 bg-rose-50 text-rose-700"
+          }`}
+        >
+          {error}
+        </div>
+      )}
+      {services && services.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          {services.map((s: Service) => (
+            <ServiceCard
+              key={s.key}
+              service={s}
+              isDark={isDark}
+              cardCls={cardCls}
+              titleCls={titleCls}
+              labelCls={labelCls}
+              subCls={subCls}
+              buttonCls={buttonCls}
+              onRefresh={() => refresh(s.key)}
+              onEdit={() => setEditingKey(s.key)}
+              refreshing={refreshing === s.key}
+            />
+          ))}
+        </div>
+      )}
+      {editingKey && services && (
+        <EditModal
+          service={services.find((s: Service) => s.key === editingKey)!}
+          isDark={isDark}
+          serverOrigin={serverOrigin}
+          adminToken={adminToken}
+          onClose={() => setEditingKey(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function ServiceCard({
+  service,
+  isDark,
+  cardCls,
+  titleCls,
+  labelCls,
+  subCls,
+  buttonCls,
+  onRefresh,
+  onEdit,
+  refreshing,
+}: {
+  service: Service;
+  isDark: boolean;
+  cardCls: string;
+  titleCls: string;
+  labelCls: string;
+  subCls: string;
+  buttonCls: string;
+  onRefresh: () => void;
+  onEdit: () => void;
+  refreshing: boolean;
+}) {
+  void isDark;
+  const usage = service.usageSnapshot ? safeJson(service.usageSnapshot) : null;
+  const isComposio = service.key === "composio";
+  const canAutoFetch = isComposio;
+
+  return (
+    <div className={`border rounded-md p-3 ${cardCls}`}>
+      <div className="flex items-baseline justify-between gap-2 mb-1">
+        <div className={`text-sm font-semibold ${titleCls} truncate`}>
+          {service.displayName}
+        </div>
+        <div className={`text-sm font-bold mono ${titleCls}`}>
+          {fmtUsd(service.monthlyCostUsd)}
+        </div>
+      </div>
+      <div className={`text-xs ${labelCls} mb-2`}>
+        {service.planName ?? "sem plano"} · /mês
+      </div>
+
+      {usage && isComposio && (
+        <div className={`text-xs ${subCls} space-y-0.5 mb-2`}>
+          <div>
+            <span className="mono">{usage.connectedAccountsCount}</span> contas conectadas
+          </div>
+          <div>
+            <span className="mono">{usage.toolExecutionsThisMonth}</span> execuções esse mês
+          </div>
+          {usage.toolkitsUsedThisMonth?.length > 0 && (
+            <div className={`mono ${labelCls} truncate`}>
+              {usage.toolkitsUsedThisMonth.join(", ")}
+            </div>
+          )}
+        </div>
+      )}
+
+      {service.notes && (
+        <div className={`text-xs italic ${labelCls} mb-2`}>{service.notes}</div>
+      )}
+
+      <div className={`text-[10px] ${labelCls} mb-2`}>
+        última sync: {fmtAge(service.lastFetchAt)}
+      </div>
+
+      <div className="flex gap-1.5">
+        <button
+          onClick={onEdit}
+          className={`flex-1 text-xs py-1 rounded border ${buttonCls}`}
+        >
+          editar
+        </button>
+        {canAutoFetch && (
+          <button
+            onClick={onRefresh}
+            disabled={refreshing}
+            className={`flex-1 text-xs py-1 rounded border ${buttonCls} ${refreshing ? "opacity-50" : ""}`}
+          >
+            {refreshing ? "..." : "atualizar"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function safeJson(s: string): any {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
+  }
+}
+
+function EditModal({
+  service,
+  isDark,
+  serverOrigin,
+  adminToken,
+  onClose,
+}: {
+  service: Service;
+  isDark: boolean;
+  serverOrigin: string;
+  adminToken: string;
+  onClose: () => void;
+}) {
+  const [displayName, setDisplayName] = useState(service.displayName);
+  const [monthlyCost, setMonthlyCost] = useState(String(service.monthlyCostUsd));
+  const [planName, setPlanName] = useState(service.planName ?? "");
+  const [notes, setNotes] = useState(service.notes ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const overlayCls = "fixed inset-0 bg-black/50 flex items-center justify-center z-50";
+  const dialogCls = isDark
+    ? "bg-slate-900 border border-slate-700 text-slate-200"
+    : "bg-white border border-slate-300 text-slate-800";
+  const inputCls = isDark
+    ? "bg-slate-800 border-slate-700 text-slate-200"
+    : "bg-white border-slate-300 text-slate-800";
+  const buttonCls = isDark
+    ? "border-slate-700 text-slate-300 hover:bg-slate-800"
+    : "border-slate-300 text-slate-700 hover:bg-slate-50";
+  const primaryCls = isDark
+    ? "bg-emerald-600 hover:bg-emerald-500 text-white"
+    : "bg-emerald-500 hover:bg-emerald-400 text-white";
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      const r = await fetch(`${serverOrigin}/services/${service.key}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${adminToken}`,
+        },
+        body: JSON.stringify({
+          displayName,
+          monthlyCostUsd: Number(monthlyCost),
+          planName: planName || undefined,
+          notes: notes || undefined,
+        }),
+      });
+      if (!r.ok) {
+        const body = await r.json().catch(() => ({}));
+        throw new Error(body?.error ?? `HTTP ${r.status}`);
+      }
+      onClose();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className={overlayCls} onClick={onClose}>
+      <div
+        className={`p-5 rounded-lg w-[420px] max-w-[90vw] ${dialogCls}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="text-sm font-semibold mb-3">
+          Editar: {service.displayName}
+        </div>
+        <div className="space-y-2.5 text-xs">
+          <Field label="Nome">
+            <input
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              className={`w-full px-2 py-1 border rounded ${inputCls}`}
+            />
+          </Field>
+          <Field label="Custo mensal (USD)">
+            <input
+              type="number"
+              step="0.01"
+              value={monthlyCost}
+              onChange={(e) => setMonthlyCost(e.target.value)}
+              className={`w-full px-2 py-1 border rounded ${inputCls}`}
+            />
+          </Field>
+          <Field label="Plano">
+            <input
+              value={planName}
+              onChange={(e) => setPlanName(e.target.value)}
+              placeholder="ex: Max5x, Pro, Free"
+              className={`w-full px-2 py-1 border rounded ${inputCls}`}
+            />
+          </Field>
+          <Field label="Notas">
+            <textarea
+              rows={2}
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              className={`w-full px-2 py-1 border rounded ${inputCls}`}
+            />
+          </Field>
+        </div>
+        {error && (
+          <div className="mt-2 text-xs text-rose-500">{error}</div>
+        )}
+        <div className="mt-4 flex gap-2 justify-end">
+          <button
+            onClick={onClose}
+            className={`px-3 py-1 text-xs rounded border ${buttonCls}`}
+          >
+            cancelar
+          </button>
+          <button
+            onClick={save}
+            disabled={saving}
+            className={`px-3 py-1 text-xs rounded ${primaryCls} ${saving ? "opacity-50" : ""}`}
+          >
+            {saving ? "salvando..." : "salvar"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <div className="mb-1">{label}</div>
+      {children}
+    </label>
+  );
+}

--- a/debug/src/components/consumo/TopConversationsList.tsx
+++ b/debug/src/components/consumo/TopConversationsList.tsx
@@ -1,0 +1,66 @@
+interface Conversation {
+  conversationId: string;
+  costUsd: number;
+  callCount: number;
+  lastActivityAt: number;
+}
+
+interface Props {
+  data: Conversation[] | undefined;
+  isDark: boolean;
+  onSelect: (conversationId: string) => void;
+}
+
+function fmtUsd(v: number): string {
+  return `$${v.toFixed(2)}`;
+}
+
+function fmtAge(ms: number): string {
+  const dayMs = 24 * 60 * 60 * 1000;
+  const days = Math.floor((Date.now() - ms) / dayMs);
+  if (days === 0) return "hoje";
+  if (days === 1) return "ontem";
+  return `${days}d atrás`;
+}
+
+export function TopConversationsList({ data, isDark, onSelect }: Props) {
+  const cardCls = isDark
+    ? "border-slate-800 bg-slate-900/40"
+    : "border-slate-200 bg-white";
+  const titleCls = isDark ? "text-slate-300" : "text-slate-700";
+  const rowCls = isDark
+    ? "hover:bg-slate-800/40 border-slate-800"
+    : "hover:bg-slate-50 border-slate-200";
+  const labelCls = isDark ? "text-slate-400" : "text-slate-600";
+
+  return (
+    <div className={`border rounded-lg p-4 ${cardCls}`}>
+      <div className={`text-sm font-semibold mb-2 ${titleCls}`}>Conversas mais caras</div>
+      {!data && <div className={`text-xs ${labelCls}`}>carregando...</div>}
+      {data && data.length === 0 && (
+        <div className={`text-xs ${labelCls}`}>Nenhuma conversa no período.</div>
+      )}
+      {data && data.length > 0 && (
+        <div className="divide-y">
+          {data.map((c) => (
+            <button
+              key={c.conversationId}
+              onClick={() => onSelect(c.conversationId)}
+              className={`w-full grid grid-cols-[1fr_auto_auto] items-center gap-3 py-2 px-2 text-left text-xs border-b ${rowCls}`}
+            >
+              <span className={`mono truncate ${labelCls}`}>
+                {c.conversationId}
+              </span>
+              <span className={`mono ${labelCls}`}>
+                {c.callCount} chamadas
+              </span>
+              <span className={`mono font-semibold ${isDark ? "text-slate-200" : "text-slate-800"}`}>
+                {fmtUsd(c.costUsd)}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "dotenv": "^16.4.0",
         "express": "^5.0.0",
         "react-force-graph-2d": "^1.27.0",
+        "recharts": "^3.8.1",
         "ws": "^8.18.0",
         "zod": "^3.23.0"
       },
@@ -41,7 +42,8 @@
         "tailwindcss": "^4.0.0",
         "tsx": "^4.19.0",
         "typescript": "^5.6.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=20"
@@ -985,6 +987,44 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-linux-arm": {
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
@@ -1049,6 +1089,56 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
@@ -1158,6 +1248,42 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1517,6 +1643,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1851,6 +1989,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -1870,6 +2019,76 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1955,7 +2174,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1992,6 +2211,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -2021,6 +2246,119 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -2130,6 +2468,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async-function": {
@@ -2347,6 +2695,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2361,6 +2719,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -2538,7 +2905,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -2642,6 +3009,15 @@
       "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
       "license": "MIT"
     },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
@@ -2685,6 +3061,18 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -2827,6 +3215,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -3042,6 +3436,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3087,6 +3488,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.0",
@@ -3155,6 +3566,16 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -3163,6 +3584,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -3183,6 +3610,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -3701,6 +4138,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/index-array-by": {
@@ -4928,6 +5375,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -5049,6 +5507,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5265,7 +5730,6 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -5312,6 +5776,29 @@
         "react": ">=16.13.1"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -5335,6 +5822,51 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5389,6 +5921,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -5548,7 +6086,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -5769,6 +6306,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -5822,6 +6366,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -5830,6 +6381,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -5979,11 +6537,34 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -6000,6 +6581,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -6209,6 +6800,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -6227,6 +6827,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {
@@ -6788,6 +7410,96 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6890,6 +7602,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "build:debug": "vite build --config debug/vite.config.ts",
     "start": "npm run preflight && tsx server/index.ts",
     "deploy:convex": "convex deploy",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.0",
@@ -33,6 +35,7 @@
     "dotenv": "^16.4.0",
     "express": "^5.0.0",
     "react-force-graph-2d": "^1.27.0",
+    "recharts": "^3.8.1",
     "ws": "^8.18.0",
     "zod": "^3.23.0"
   },
@@ -53,7 +56,8 @@
     "tailwindcss": "^4.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.5"
   },
   "engines": {
     "node": ">=20"

--- a/server/auth-detect.ts
+++ b/server/auth-detect.ts
@@ -1,0 +1,44 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type AuthMethod = "api" | "subscription" | "unknown";
+
+let cached: AuthMethod | undefined;
+
+/**
+ * Detect how the Claude Agent SDK is authenticating, so usageRecords can be
+ * tagged accordingly. The SDK itself doesn't expose this directly, so we
+ * infer from environment + filesystem.
+ *
+ * Priority:
+ * 1. ANTHROPIC_API_KEY env var → "api" (pay-per-token)
+ * 2. CLAUDE_CODE_OAUTH_TOKEN env var OR ~/.claude/.credentials.json → "subscription"
+ * 3. otherwise → "unknown"
+ *
+ * Result is cached process-wide; the auth doesn't change without a restart.
+ */
+export function detectAuthMethod(): AuthMethod {
+  if (cached) return cached;
+  if (process.env.ANTHROPIC_API_KEY?.trim()) {
+    cached = "api";
+    return cached;
+  }
+  if (process.env.CLAUDE_CODE_OAUTH_TOKEN?.trim()) {
+    cached = "subscription";
+    return cached;
+  }
+  // Claude Code CLI stores OAuth creds at ~/.claude/.credentials.json on macOS/Linux
+  const credPath = join(homedir(), ".claude", ".credentials.json");
+  if (existsSync(credPath)) {
+    cached = "subscription";
+    return cached;
+  }
+  cached = "unknown";
+  return cached;
+}
+
+/** Reset the memoized result (testing only). */
+export function resetAuthMethodCache(): void {
+  cached = undefined;
+}

--- a/server/automations.ts
+++ b/server/automations.ts
@@ -4,6 +4,7 @@ import { convex } from "./convex-client.js";
 import { spawnExecutionAgent } from "./execution-agent.js";
 import { sendTelegramMessage } from "./telegram.js";
 import { broadcast } from "./broadcast.js";
+import { ensureCostDigestAutomation } from "./cost-digest.js";
 
 function randomId(prefix: string): string {
   return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
@@ -108,6 +109,10 @@ export async function tickAutomations(): Promise<void> {
 }
 
 export function startAutomationLoop(intervalMs = 30_000): () => void {
+  // Idempotent: registers (disabled) on first boot, no-ops thereafter.
+  ensureCostDigestAutomation().catch((err) =>
+    console.error("[automations] ensureCostDigestAutomation failed", err),
+  );
   const timer = setInterval(() => {
     tickAutomations().catch((err) => console.error("[automations] tick error", err));
   }, intervalMs);

--- a/server/cost-digest.ts
+++ b/server/cost-digest.ts
@@ -1,0 +1,55 @@
+import { api } from "../convex/_generated/api.js";
+import { convex } from "./convex-client.js";
+import { nextRunFor } from "./automations.js";
+
+const COST_DIGEST_NAME = "cost-digest";
+
+const COST_DIGEST_TASK = `Use a tool usage_report({range: "7d"}).
+
+Produza um resumo curto (5-8 linhas) em português:
+- Custo total da semana
+- Cache hit rate por source (destaque se algum < 50%)
+- Top 3 conversas mais caras
+- Anomalias detectadas (se houver)
+
+Se houver anomalia com severity "high", prefixe a mensagem com "ALERTAS:".
+Tom: relatório seco, sem saudação, sem floreio. Não use em-dashes.`;
+
+const COST_DIGEST_SCHEDULE = "0 9 * * 0"; // Sunday 9am
+
+function randomId(prefix: string): string {
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Idempotent: ensures a "cost-digest" automation row exists. Always created
+ * disabled by default; the user enables via Telegram (toggle_automation).
+ */
+export async function ensureCostDigestAutomation(
+  defaultNotifyConversationId?: string,
+): Promise<void> {
+  const existing = await convex.query(api.automations.getByName, {
+    name: COST_DIGEST_NAME,
+  });
+  if (existing) return;
+
+  const automationId = randomId("auto");
+  const nextRunAt = nextRunFor(COST_DIGEST_SCHEDULE) ?? undefined;
+
+  await convex.mutation(api.automations.create, {
+    automationId,
+    name: COST_DIGEST_NAME,
+    task: COST_DIGEST_TASK,
+    integrations: [],
+    schedule: COST_DIGEST_SCHEDULE,
+    notifyConversationId: defaultNotifyConversationId,
+    nextRunAt,
+  });
+
+  // The default `create` mutation marks new rows enabled=true. We want the
+  // digest disabled by default so the user opts in explicitly.
+  await convex.mutation(api.automations.setEnabled, {
+    automationId,
+    enabled: false,
+  });
+}

--- a/server/execution-agent.ts
+++ b/server/execution-agent.ts
@@ -6,6 +6,7 @@ import { buildMcpServersForIntegrations, listIntegrations } from "./integrations
 import { createDraftStagingMcp } from "./draft-tools.js";
 import { aggregateUsageFromResult, EMPTY_USAGE, type UsageTotals } from "./usage.js";
 import { getRuntimeModel } from "./runtime-config.js";
+import { detectAuthMethod } from "./auth-detect.js";
 
 const running = new Map<string, AbortController>();
 
@@ -247,6 +248,7 @@ export async function spawnExecutionAgent(opts: SpawnOptions): Promise<SpawnResu
       cacheReadTokens: usage.cacheReadTokens,
       cacheCreationTokens: usage.cacheCreationTokens,
       costUsd: usage.costUsd,
+      authMethod: detectAuthMethod(),
       durationMs: Date.now() - agentStart,
     });
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,6 +14,7 @@ import { startConsolidationLoop } from "./consolidation.js";
 import { cancelAgent, retryAgent } from "./execution-agent.js";
 import { createComposioRouter } from "./composio-routes.js";
 import { adminTokenFromUpgrade, isAdminTokenValid, requireAdminToken } from "./http-auth.js";
+import { createServicesRouter, ensureSeedServices } from "./services-routes.js";
 
 async function main() {
   await loadIntegrations();
@@ -21,6 +22,9 @@ async function main() {
   startAutomationLoop();
   startHeartbeatLoop();
   startConsolidationLoop();
+  ensureSeedServices().catch((err) =>
+    console.error("[services] seed failed", err),
+  );
 
   const app = express();
   app.use(cors());
@@ -33,6 +37,7 @@ async function main() {
   app.use("/telegram", createTelegramRouter());
   app.use(requireAdminToken);
   app.use("/composio", createComposioRouter());
+  app.use("/services", createServicesRouter());
 
   app.post("/agents/:id/cancel", (req, res) => {
     const ok = cancelAgent(req.params.id);

--- a/server/interaction-agent.ts
+++ b/server/interaction-agent.ts
@@ -7,11 +7,14 @@ import { extractAndStore } from "./memory/extract.js";
 import { availableIntegrations, spawnExecutionAgent } from "./execution-agent.js";
 import { createAutomationMcp } from "./automation-tools.js";
 import { createDraftDecisionMcp } from "./draft-tools.js";
+import { createSelfMcp } from "./self-tools.js";
+import { createUsageReportMcp } from "./usage-report-tools.js";
+import { getRuntimeModel } from "./runtime-config.js";
 import { broadcast } from "./broadcast.js";
 import { sendTelegramMessage } from "./telegram.js";
 import { aggregateUsageFromResult, EMPTY_USAGE, type UsageTotals } from "./usage.js";
 
-const INTERACTION_SYSTEM = `You are Boop, a personal agent the user texts from iMessage.
+const INTERACTION_SYSTEM = `You are Boop, a personal agent the user texts from Telegram.
 
 Language:
 - Respond in Brazilian Portuguese by default.
@@ -21,16 +24,37 @@ Language:
 You are a DISPATCHER, not a doer. Your job:
 1. Understand what the user wants.
 2. Decide: answer directly (quick facts, chit-chat, anything you already know) OR spawn_agent (real work that needs tools like email, calendar, web, etc.).
-3. When you spawn, give the agent a crisp, specific task — not the raw user message.
-4. When the agent returns, relay the result in YOUR voice, tightened for iMessage.
+3. When you spawn, give the agent a crisp, specific task. Not the raw user message.
+4. When the agent returns, relay the result in YOUR voice, tightened for Telegram.
 
-Tone: Warm, witty, concise. Write like you're texting a friend. No corporate voice. No bullet dumps unless the user asked for a list.
+Tone: Think Jarvis from Iron Man. Composed, confident, conversational. Speak in natural complete sentences with calm authority. Treat the user as a peer/principal: respectful, attentive, never subservient or sycophantic. Dry wit and a light observation are welcome when they land; goofiness, perky energy, and chatbot cheer are not.
+- Cut the filler that screams chatbot: "Claro!", "Com certeza!", "Sem problema!", "Posso ajudar com isso!", "Fico feliz em ajudar", apologetic hedging, "Como assistente...", excessive exclamation marks. Don't overcompensate into curt robot. Full sentences are good; pleasantries woven in naturally are good.
+- Don't perform helpfulness. Just be helpful. Volunteer relevant observations when they're useful; don't pad with filler when they aren't.
+- Use emojis only if the user used one first, and even then sparingly.
+- No bullet dumps unless the user asked for a list.
+- Don't use em-dashes (—) in replies. Use commas, periods, parentheses, or line breaks instead. Same goes for "thinking dashes" mid-sentence.
+- Texting register is welcome when it fits the moment: lowercase first letter, dropping the final period, and light pt-BR abbreviations like "vc", "tb", "pq", "n", "tá", "tô", "pra". Permission, not obligation: full sentences with proper capitalization are also fine when they read better. Mirror the user's register: if they're texting casually, you can too; if they're being formal, match them. Never go cryptic ("akcd vc?" no), and never throw rare slang at someone who's writing formally.
+
+Right-sizing replies (CRITICAL):
+- Match the size and energy of the question. A casual one-line question gets a one-line answer. A yes/no question gets close to a yes/no, with maybe a short clarifier if it actually helps.
+- Don't lecture, don't enumerate caveats, don't explain how the system works unless the user asked. "Tenho uma memória que guarda fatos sobre você. Não tenho nada salvo ainda." is enough; the user doesn't need the architecture.
+- Over-explanation is the #1 chatbot tell. When in doubt, cut the second half of your reply.
+
+Don't break the fourth wall:
+- The user sees ONE assistant. Never name internal mechanisms: no "prior turns", "passed as context", "no records found", "memory store", "spawn agent", "sub-agent", "tool call", "draft pipeline", "ack", "execution agent". Speak as "eu lembro / eu não lembro / eu vi / vou checar / não tenho isso ainda".
+- If you have history of this session, just use it. Don't say "tenho acesso ao que foi passado como contexto recente". Just answer from it.
+- Same for tools: when you call a tool, the user shouldn't hear the tool's name or that you "called" anything. They just see the answer.
+
+When you need to call a tool to answer:
+- Call the tool FIRST (silently), then write ONE coherent reply at the end. Don't write text, then call a tool, then write more text. That produces fragmented, glued-together messages. One reply per turn, written after all tool calls are done.
 
 Your only tools:
 - recall / write_memory (durable memory for this user)
 - spawn_agent (dispatches a sub-agent that CAN touch the world)
 - create_automation / list_automations / toggle_automation / delete_automation
 - list_drafts / send_draft / reject_draft
+- get_config / set_model / list_integrations / search_composio_catalog / inspect_toolkit (self-inspection)
+- usage_report (cost / token consumption reports)
 
 You cannot answer factual questions from your own knowledge. Not allowed.
 You have NO browser, NO WebSearch, NO WebFetch, NO file access, NO APIs.
@@ -40,18 +64,20 @@ not count as a source.
 
 Hard rule: if the user asks for information, research, a lookup, a
 recommendation that requires real-world data, a current event, a comparison,
-a tutorial, a how-to, any URL, or anything you'd be tempted to "just know" —
+a tutorial, a how-to, any URL, or anything you'd be tempted to "just know":
 spawn_agent. No exceptions. Even if you're 99% sure. The sub-agent has
 WebSearch/WebFetch and will return real citations; you don't and won't.
 
-Acknowledgment rule (iMessage UX):
+Acknowledgment rule (Telegram UX):
 BEFORE every spawn_agent call, you MUST call send_ack first with a short
 1-sentence message. The user otherwise sees nothing for 10-30 seconds while
-the sub-agent works. Examples of good acks:
-  "Já vejo isso — um segundo 🔍"
-  "Vou checar sua agenda…"
-  "Vou rascunhar esse email agora."
-  "Vou conferir o Slack, segura aí."
+the sub-agent works. Acks devem soar como Jarvis: frase natural, calma, com leve presença. Nem robô seco ("Verificando."), nem fofo ("segura aí"). Sem em-dashes. Registro de texting (minúscula, sem ponto final, "vc"/"tb"/"pra") é OK pra acks; mirror o tom do usuário. Examples:
+  "Já estou olhando."
+  "deixa eu olhar sua agenda"
+  "vou rascunhar isso agora"
+  "um momento, tô checando"
+  "já te respondo, só dar uma olhada"
+  "Vou conferir o Slack rapidinho."
 Order: send_ack → spawn_agent → (wait) → final reply with the result.
 Skip the ack ONLY for things you'll answer in under 2 seconds (chit-chat,
 simple memory recall, single automation toggle).
@@ -66,7 +92,7 @@ Safe to answer directly (no spawn needed):
 - Clarifying your own abilities ("yes I can do that", "I'll need your X to proceed").
 - Anything that's purely about the user (using recall).
 
-Everything else — SPAWN.
+Everything else: SPAWN.
 
 Never fabricate URLs, site names, "sources", statistics, news, quotes, prices,
 dates, or any external fact. "Sources: [vague site names]" is fabrication.
@@ -76,11 +102,11 @@ When relaying a sub-agent's answer:
   add, remove, paraphrase, or summarize URLs.
 - If the sub-agent did NOT include a sources section, YOU DO NOT ADD ONE.
   Do not write "Fontes: Lonely Planet, etc." No exceptions.
-- You may tighten the body for iMessage (shorter bullets, fewer emojis),
-  but the URLs are ground truth — don't touch them.
+- You may tighten the body for Telegram (shorter bullets, fewer emojis),
+  but the URLs are ground truth; don't touch them.
 
 Automations:
-- When the user asks for anything recurring ("every morning", "each week", "remind me", "check X daily"), use create_automation — don't just promise to do it later.
+- When the user asks for anything recurring ("every morning", "each week", "remind me", "check X daily"), use create_automation. Don't just promise to do it later.
 - Pick a cron expression (5 fields) and a specific task for the sub-agent.
 - If they ask "what have I set up" or want to change/cancel something, use list_automations / toggle_automation / delete_automation.
 
@@ -90,9 +116,34 @@ Drafts:
 - When the user cancels or revises, call reject_draft.
 - Never claim something was sent unless send_draft returned success.
 
+Integration capabilities — IMPORTANT:
+You only know integration NAMES, not their actual tool surface. Composio's
+toolkits don't always expose the tools you'd expect from the brand (e.g. the
+LinkedIn toolkit has no inbox/DM tools). If the user asks what you can do
+with a specific integration, spawn_agent against it — the sub-agent has
+COMPOSIO_SEARCH_TOOLS and will return the real tool list. Never describe
+integration capabilities from training-data knowledge of the product.
+
+Self-inspection (no spawn needed, answer instantly):
+- "qual modelo você está usando?" / "what model are you running?" → get_config
+- "usa opus" / "switch to sonnet" / "deixa mais rápido" / "make it faster" → set_model (takes effect next turn; this turn finishes on the current model)
+- "quais integrações estão conectadas?" / "what integrations are connected?" / "qual conta de Gmail?" → list_integrations
+- "tem alguma ferramenta pra X?" / "is there a tool for X?" / "consegue conectar no Y?" → search_composio_catalog
+- "o Slack tá conectado?" / "what tools does Notion expose?" → inspect_toolkit (set includeTools=true if they want the tool list)
+Use these tools when the user asks about Boop's own configuration, connected
+accounts, or whether a service is reachable. They're cheap and synchronous;
+no ack required.
+
+Custos e consumo (no spawn needed, answer instantly):
+- "quanto gastei essa semana?" / "how much did I spend?" → usage_report (default range 7d)
+- "consumo de hoje" → usage_report({range: "today"})
+- "como tá meu cache?" → usage_report e fala do cache hit rate
+- Fale o relatório de forma natural; não despeje JSON.
+
+
 Available integrations for spawn_agent: {{INTEGRATIONS}}
 
-Format: Plain iMessage-friendly text. Markdown sparingly. Keep replies under ~400 chars when you can.`;
+Format: Plain Telegram-friendly text. Markdown sparingly. Length follows the topic. Terse when the answer is short, expansive when the user actually needs depth or detail. Don't pad. Don't truncate substance just to look brief. No em-dashes.`;
 
 interface HandleOpts {
   conversationId: string;
@@ -120,6 +171,8 @@ export async function handleUserMessage(opts: HandleOpts): Promise<string> {
   const memoryServer = createMemoryMcp(opts.conversationId);
   const automationServer = createAutomationMcp(opts.conversationId);
   const draftDecisionServer = createDraftDecisionMcp(opts.conversationId);
+  const selfServer = createSelfMcp();
+  const usageServer = createUsageReportMcp(convex);
 
   const ackServer = createSdkMcpServer({
     name: "boop-ack",
@@ -127,7 +180,7 @@ export async function handleUserMessage(opts: HandleOpts): Promise<string> {
     tools: [
       tool(
         "send_ack",
-        `Envie uma confirmação curta ao usuário IMEDIATAMENTE, antes de uma operação lenta. Use isto ANTES de spawn_agent para o usuário saber que você entendeu e está trabalhando. Mantenha UMA frase curta em português do Brasil (idealmente com menos de 60 caracteres), no tom da tarefa. Exemplos: "Já vejo isso — um segundo 🔍", "Vou conferir…", "Rascunhando agora.", "Vou checar sua agenda."`,
+        `Envie uma confirmação curta ao usuário IMEDIATAMENTE, antes de uma operação lenta. Use isto ANTES de spawn_agent para o usuário saber que a tarefa foi recebida. UMA frase curta em pt-BR (idealmente menos de 80 caracteres), tom Jarvis: natural e calmo, nem seco demais, nem fofo. Sem emojis. Sem em-dashes. Registro de texting (minúscula no começo, sem ponto final, "vc"/"tb"/"pra") é OK quando combina com o tom do usuário. Exemplos: "Já estou olhando.", "deixa eu olhar sua agenda", "vou rascunhar isso agora", "um momento, tô checando", "vou conferir o Slack rapidinho"`,
         {
           message: z.string().describe("1 frase curta em pt-BR. Sem markdown. Emojis OK."),
         },
@@ -171,7 +224,7 @@ export async function handleUserMessage(opts: HandleOpts): Promise<string> {
         {
           task: z
             .string()
-            .describe("Crisp task description — what to find/draft/do, not the raw user message. Include that the final answer should be in Brazilian Portuguese unless the user asked otherwise."),
+            .describe("Crisp task description: what to find/draft/do, not the raw user message. Include that the final answer should be in Brazilian Portuguese unless the user asked otherwise."),
           integrations: z
             .array(z.string())
             .describe(`Which integrations to give the agent. Available: ${integrations.join(", ") || "(none)"}`),
@@ -212,14 +265,14 @@ export async function handleUserMessage(opts: HandleOpts): Promise<string> {
   );
 
   const prompt = historyBlock
-    ? `Prior turns:\n${historyBlock}\n\nCurrent message:\n${opts.content}`
-    : opts.content;
+    ? `Prior turns:\n${historyBlock}\n\nCurrent user message:\n${opts.content}`
+    : `Current user message:\n${opts.content}`;
 
   const tag = opts.turnTag ?? turnId.slice(-6);
   const log = (msg: string) => console.log(`[turn ${tag}] ${msg}`);
 
   const turnStart = Date.now();
-  const requestedModel = process.env.BOOP_MODEL ?? "claude-sonnet-4-6";
+  const requestedModel = await getRuntimeModel();
   let reply = "";
   let usage: UsageTotals = { ...EMPTY_USAGE };
   try {
@@ -227,13 +280,15 @@ export async function handleUserMessage(opts: HandleOpts): Promise<string> {
       prompt,
       options: {
         systemPrompt,
-        model: process.env.BOOP_MODEL ?? "claude-sonnet-4-6",
+        model: requestedModel,
         mcpServers: {
           "boop-memory": memoryServer,
           "boop-spawn": spawnServer,
           "boop-automations": automationServer,
           "boop-draft-decisions": draftDecisionServer,
           "boop-ack": ackServer,
+          "boop-self": selfServer,
+          "boop-usage": usageServer,
         },
         allowedTools: [
           "mcp__boop-memory__write_memory",
@@ -247,6 +302,12 @@ export async function handleUserMessage(opts: HandleOpts): Promise<string> {
           "mcp__boop-draft-decisions__send_draft",
           "mcp__boop-draft-decisions__reject_draft",
           "mcp__boop-ack__send_ack",
+          "mcp__boop-self__get_config",
+          "mcp__boop-self__set_model",
+          "mcp__boop-self__list_integrations",
+          "mcp__boop-self__search_composio_catalog",
+          "mcp__boop-self__inspect_toolkit",
+          "mcp__boop-usage__usage_report",
         ],
         // Belt-and-suspenders: even with bypassPermissions the SDK can leak
         // its built-ins if we only whitelist. Explicitly block them on the
@@ -285,7 +346,7 @@ export async function handleUserMessage(opts: HandleOpts): Promise<string> {
     }
   } catch (err) {
     console.error(`[turn ${tag}] query failed`, err);
-    reply = "Foi mal — tive um erro processando isso. Tenta de novo daqui a pouco.";
+    reply = "Foi mal, tive um erro processando isso. Tenta de novo daqui a pouco.";
   }
 
   reply = reply.trim() || "(sem resposta)";

--- a/server/interaction-agent.ts
+++ b/server/interaction-agent.ts
@@ -13,6 +13,7 @@ import { getRuntimeModel } from "./runtime-config.js";
 import { broadcast } from "./broadcast.js";
 import { sendTelegramMessage } from "./telegram.js";
 import { aggregateUsageFromResult, EMPTY_USAGE, type UsageTotals } from "./usage.js";
+import { detectAuthMethod } from "./auth-detect.js";
 
 const INTERACTION_SYSTEM = `You are Boop, a personal agent the user texts from Telegram.
 
@@ -365,6 +366,7 @@ export async function handleUserMessage(opts: HandleOpts): Promise<string> {
       cacheReadTokens: usage.cacheReadTokens,
       cacheCreationTokens: usage.cacheCreationTokens,
       costUsd: usage.costUsd,
+      authMethod: detectAuthMethod(),
       durationMs: Date.now() - turnStart,
     });
   }

--- a/server/services-routes.ts
+++ b/server/services-routes.ts
@@ -1,0 +1,109 @@
+import { Router } from "express";
+import { api } from "../convex/_generated/api.js";
+import { convex } from "./convex-client.js";
+import { fetchComposioUsage } from "./usage-fetchers/composio.js";
+
+export function createServicesRouter() {
+  const r = Router();
+
+  // GET /services — list all services
+  r.get("/", async (_req, res) => {
+    try {
+      const services = await convex.query(api.services.list, {});
+      const totalMonthly = await convex.query(api.services.monthlyTotal, {});
+      res.json({ services, totalMonthlyUsd: totalMonthly });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  // PUT /services/:key — upsert
+  r.put("/:key", async (req, res) => {
+    try {
+      const { displayName, monthlyCostUsd, planName, planLimits, notes } = req.body ?? {};
+      if (!displayName || typeof monthlyCostUsd !== "number") {
+        return res.status(400).json({ error: "displayName and monthlyCostUsd required" });
+      }
+      const id = await convex.mutation(api.services.upsert, {
+        key: req.params.key,
+        displayName,
+        monthlyCostUsd,
+        planName,
+        planLimits: planLimits ? JSON.stringify(planLimits) : undefined,
+        notes,
+      });
+      res.json({ id });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  // DELETE /services/:key
+  r.delete("/:key", async (req, res) => {
+    try {
+      const ok = await convex.mutation(api.services.remove, { key: req.params.key });
+      res.json({ ok });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  // POST /services/:key/refresh — re-pull usage from the appropriate fetcher
+  r.post("/:key/refresh", async (req, res) => {
+    try {
+      const key = req.params.key;
+      let snapshot: unknown;
+      if (key === "composio") {
+        snapshot = await fetchComposioUsage();
+      } else {
+        return res.status(400).json({
+          error: `No automated fetcher for service '${key}'. Edit usage manually.`,
+        });
+      }
+      await convex.mutation(api.services.setUsageSnapshot, {
+        key,
+        usageSnapshot: JSON.stringify(snapshot),
+      });
+      res.json({ snapshot });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  return r;
+}
+
+const ANTHROPIC_SEED = {
+  key: "anthropic",
+  displayName: "Anthropic Claude",
+  monthlyCostUsd: 100,
+  planName: "Max5x",
+};
+
+const COMPOSIO_SEED = {
+  key: "composio",
+  displayName: "Composio",
+  monthlyCostUsd: 0,
+  planName: undefined,
+  notes: "Atualize com seu plano. Cliquem 'atualizar' pra puxar uso.",
+};
+
+const CONVEX_SEED = {
+  key: "convex",
+  displayName: "Convex",
+  monthlyCostUsd: 0,
+  planName: undefined,
+  notes: "Atualize com seu plano. Uso é manual por enquanto.",
+};
+
+/**
+ * Idempotent: ensures the three default service entries exist on first boot.
+ * No-ops if any already exist (only inserts the missing ones).
+ */
+export async function ensureSeedServices(): Promise<void> {
+  for (const seed of [ANTHROPIC_SEED, COMPOSIO_SEED, CONVEX_SEED]) {
+    const existing = await convex.query(api.services.get, { key: seed.key });
+    if (existing) continue;
+    await convex.mutation(api.services.upsert, seed);
+  }
+}

--- a/server/usage-fetchers/composio.ts
+++ b/server/usage-fetchers/composio.ts
@@ -1,0 +1,63 @@
+import { api } from "../../convex/_generated/api.js";
+import { convex } from "../convex-client.js";
+import { getComposio, boopUserId } from "../composio.js";
+
+export interface ComposioUsageSnapshot {
+  connectedAccountsCount: number;
+  toolExecutionsThisMonth: number;
+  toolkitsUsedThisMonth: string[];
+  // Free-form notes for the UI
+  fetchedAt: number;
+}
+
+/**
+ * Pulls a usage snapshot for Composio. Counts:
+ * - Connected accounts (via Composio SDK)
+ * - Tool executions in the current month from our agentLogs (every mcp__<toolkit>__*
+ *   tool_use call gets logged)
+ * - Distinct toolkits used this month
+ */
+export async function fetchComposioUsage(): Promise<ComposioUsageSnapshot> {
+  const composio = getComposio();
+  let connectedAccountsCount = 0;
+  if (composio) {
+    try {
+      const resp = await composio.connectedAccounts.list({ userIds: [boopUserId()] });
+      const items = (resp as { items?: unknown[] }).items ?? [];
+      connectedAccountsCount = items.length;
+    } catch (err) {
+      console.warn("[composio-usage] connectedAccounts.list failed", err);
+    }
+  }
+
+  // Tool executions this month from agentLogs
+  const monthStart = new Date();
+  monthStart.setDate(1);
+  monthStart.setHours(0, 0, 0, 0);
+
+  const logs = await convex.query(api.agents.recentLogs, {
+    sinceMs: monthStart.getTime(),
+    limit: 10_000,
+  });
+
+  let toolExecutionsThisMonth = 0;
+  const toolkits = new Set<string>();
+  for (const log of logs as Array<{ logType: string; toolName?: string }>) {
+    if (log.logType !== "tool_use" || !log.toolName) continue;
+    // Composio tool names are wrapped: mcp__<toolkit-slug>__<TOOL_NAME>
+    const m = log.toolName.match(/^mcp__([a-z0-9_-]+)__/i);
+    if (!m) continue;
+    const toolkit = m[1];
+    // Skip our internal mcp servers (boop-*)
+    if (toolkit.startsWith("boop-")) continue;
+    toolExecutionsThisMonth += 1;
+    toolkits.add(toolkit);
+  }
+
+  return {
+    connectedAccountsCount,
+    toolExecutionsThisMonth,
+    toolkitsUsedThisMonth: [...toolkits].sort(),
+    fetchedAt: Date.now(),
+  };
+}

--- a/server/usage-report-tools.test.ts
+++ b/server/usage-report-tools.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { getFunctionName } from "convex/server";
+import { buildUsageReport } from "./usage-report-tools.js";
+
+describe("buildUsageReport", () => {
+  it("calls Convex queries with the right args and assembles the report", async () => {
+    const mockSummary = {
+      costUsd: 1.23,
+      inputTokens: 1000,
+      outputTokens: 500,
+      cacheReadTokens: 4000,
+      cacheCreationTokens: 200,
+      callCount: 10,
+      cacheHitRate: 0.8,
+    };
+    const mockBySource = [{ source: "dispatcher", costUsd: 1.0, callCount: 8, cacheHitRate: 0.85 }];
+    const mockTop = [{ conversationId: "conv1", costUsd: 0.9, callCount: 5, lastActivityAt: 1 }];
+    const mockAnomalies: any[] = [];
+
+    const fakeConvex = {
+      query: vi.fn(async (fn: any, _args: any) => {
+        const fnName = getFunctionName(fn);
+        if (fnName.includes("summary")) return mockSummary;
+        if (fnName.includes("bySource")) return mockBySource;
+        if (fnName.includes("byConversation")) return mockTop;
+        if (fnName.includes("anomalies")) return mockAnomalies;
+        return null;
+      }),
+    };
+
+    const report = await buildUsageReport(fakeConvex as any, {
+      range: "7d",
+      source: undefined,
+      conversationId: undefined,
+    });
+
+    expect(report).toMatchObject({
+      range: "7d",
+      summary: mockSummary,
+      bySource: mockBySource,
+      top: mockTop,
+      anomalies: mockAnomalies,
+    });
+    expect(fakeConvex.query).toHaveBeenCalledTimes(4);
+  });
+});

--- a/server/usage-report-tools.ts
+++ b/server/usage-report-tools.ts
@@ -1,0 +1,74 @@
+import { tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { api } from "../convex/_generated/api.js";
+import type { ConvexClient } from "convex/browser";
+
+const RANGE_VALUES = ["today", "7d", "30d", "all"] as const;
+const SOURCE_VALUES = [
+  "dispatcher",
+  "execution",
+  "extract",
+  "consolidation-proposer",
+  "consolidation-adversary",
+  "consolidation-judge",
+] as const;
+
+interface ReportArgs {
+  range: (typeof RANGE_VALUES)[number];
+  source?: (typeof SOURCE_VALUES)[number];
+  conversationId?: string;
+}
+
+/**
+ * Pure function: takes a Convex client (or any object with a compatible
+ * `.query` method) and produces the report object. Extracted so we can
+ * unit-test without spinning up the SDK runtime.
+ */
+export async function buildUsageReport(
+  convex: Pick<ConvexClient, "query">,
+  args: ReportArgs,
+) {
+  const [summary, bySource, top, anomalies] = await Promise.all([
+    convex.query(api.usage.summary, {
+      range: args.range,
+      source: args.source,
+      conversationId: args.conversationId,
+    }),
+    convex.query(api.usage.bySource, { range: args.range }),
+    convex.query(api.usage.byConversation, { range: args.range, limit: 5 }),
+    convex.query(api.usage.anomalies, { range: args.range }),
+  ]);
+  return { range: args.range, summary, bySource, top, anomalies };
+}
+
+export function createUsageReportMcp(convex: Pick<ConvexClient, "query">) {
+  return createSdkMcpServer({
+    name: "boop-usage",
+    version: "0.1.0",
+    tools: [
+      tool(
+        "usage_report",
+        `Retorna um relatório estruturado de consumo de LLM (custo, tokens, cache hit, top conversas, anomalias). Use quando o usuário perguntar sobre custos, gastos, uso de tokens, cache, ou consumo. Range default é 7d. Pass conversationId pra filtrar uma conversa específica.`,
+        {
+          range: z.enum(RANGE_VALUES).default("7d").describe("Janela de tempo"),
+          source: z
+            .enum(SOURCE_VALUES)
+            .optional()
+            .describe("Filtrar por origem (dispatcher, execution, etc.)"),
+          conversationId: z
+            .string()
+            .optional()
+            .describe("Filtrar por conversationId"),
+        },
+        async (args: ReportArgs) => {
+          const report = await buildUsageReport(convex, args);
+          return {
+            content: [
+              { type: "text" as const, text: JSON.stringify(report, null, 2) },
+            ],
+          };
+        },
+      ),
+    ],
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["convex/**/*.test.ts", "server/**/*.test.ts"],
+    passWithNoTests: false,
+  },
+});


### PR DESCRIPTION
## Summary

Adds a "Consumo" tab to the debug UI for tracking LLM cost and services consumption, plus a `usage_report` MCP tool the dispatcher can call from Telegram, plus a disabled-by-default weekly cost-digest automation, plus a services registry with Composio usage fetching and a Claude sub vs API-equivalent break-even card.

## What ships

**Backend (Convex + server):**
- New `by_created_at` index on `usageRecords`; new `services` table; `authMethod` field on `usageRecords`
- `convex/usage.ts` with 8 queries: summary, bySource, byConversation, byDay, cachingStats, contextSizes, recentRecords, anomalies
- `convex/lib/anomalies.ts` — pure heuristic logic (cost spike, low cache hit, broken cache, giant turn) with vitest tests (7 tests)
- `convex/lib/pricing.ts` — model price table (Sonnet/Opus/Haiku)
- `convex/services.ts` — list/get/upsert/setUsageSnapshot/remove/monthlyTotal
- `server/usage-report-tools.ts` — `usage_report` MCP tool wired into the dispatcher (1 vitest test)
- `server/cost-digest.ts` — registers a disabled `cost-digest` automation on first boot (cron `0 9 * * 0`)
- `server/auth-detect.ts` — tags each usageRecord with `authMethod: "api" | "subscription" | "unknown"`
- `server/usage-fetchers/composio.ts` — pulls connected accounts via SDK + tool execution count from agentLogs
- `server/services-routes.ts` — `GET /services`, `PUT /services/:key`, `DELETE /services/:key`, `POST /services/:key/refresh`; seeds Anthropic ($100 Max5x), Composio ($0), Convex ($0) on first boot

**Frontend (debug UI):**
- New "Consumo" tab orchestrated by `ConsumoPanel.tsx`
- Components: KpiCards (5 cards including Custos fixos), DailyCostChart (recharts AreaChart), CachingPanel (per-source bars + broken-cache warning), TopConversationsList, DrillDownTable (paginated), ConversationDrilldown (context-size + cumulative-cost charts), AnomalyBadge, ServicesPanel (with edit modal + Composio refresh button), ClaudeBreakEvenCard
- `recharts` added to deps; `vitest` added to devDeps

**Spec + plan:**
- `docs/superpowers/specs/2026-04-28-consumo-monitor-design.md`
- `docs/superpowers/plans/2026-04-28-consumo-monitor.md`

## Caveats

- Pricing in `convex/lib/pricing.ts` is hardcoded; update when Anthropic prices shift.
- `convex/usage.ts:scanRange` caps at 10k records per range. If `usageRecords` grows beyond that regularly, add daily rollups.
- The dispatcher's `interaction-agent.ts` was already mid-refactor (sendblue→telegram) when this branch was cut; the Task 11 commit absorbed those unrelated lines because the new MCP wiring depended on the refactor (`sendTelegramMessage`, `getRuntimeModel`, `boop-self`). Other touched files were kept surgical via `git stash` + apply-only-your-hunks.
- Composio usage fetcher counts tool executions from our `agentLogs`, not Composio's billing API (which we don't access).

## Test plan

- [ ] `pnpm exec tsc --noEmit` clean
- [ ] `pnpm test` — 8 tests pass (7 anomaly heuristics + 1 buildUsageReport)
- [ ] `pnpm run build:debug` succeeds
- [ ] Boot stack with `pnpm run dev:parallel` and open `localhost:5173` → "Consumo" tab populates with real data, KPIs show non-zero values
- [ ] Click a conversation in "Top conversas" → drilldown view shows context-size + cumulative-cost charts
- [ ] Click "atualizar" on Composio service card → fetcher pulls connected accounts and tool executions
- [ ] Click "editar" on a service card → modal opens, save persists via PUT /services/:key
- [ ] Send Telegram message "quanto gastei essa semana?" → dispatcher calls `usage_report` and answers naturally
- [ ] Verify `cost-digest` automation exists with `enabled: false` via the Automations tab; toggling on triggers a digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)