### PR TITLE
tasks slice 2: due dates + filtered listing + edits

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -231,13 +231,16 @@ export default defineSchema({
     updatedAt: v.number(),
   }).index("by_key", ["key"]),
 
-  // User-anchored TODOs and reminders. Slice 1 fields only — `due`, `items`,
-  // `nextNagAt` arrive in later slices (issues #10, #11, #12).
+  // User-anchored TODOs and reminders. `due` is an absolute ms timestamp;
+  // a `due` whose time component is exactly midnight in the host TZ is
+  // treated as date-only by the dispatcher. `items` and `nextNagAt` land
+  // in later slices (issues #11, #12).
   tasks: defineTable({
     taskId: v.string(),
     conversationId: v.string(),
     description: v.string(),
     status: v.union(v.literal("open"), v.literal("closed")),
+    due: v.optional(v.number()),
     createdAt: v.number(),
     closedAt: v.optional(v.number()),
   })

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -6,6 +6,7 @@ export const create = mutation({
     taskId: v.string(),
     conversationId: v.string(),
     description: v.string(),
+    due: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const existing = await ctx.db
@@ -14,23 +15,37 @@ export const create = mutation({
       .unique();
     if (existing) return existing._id;
     return await ctx.db.insert("tasks", {
-      ...args,
+      taskId: args.taskId,
+      conversationId: args.conversationId,
+      description: args.description,
       status: "open",
+      ...(args.due !== undefined ? { due: args.due } : {}),
       createdAt: Date.now(),
     });
   },
 });
 
+// Returns all open tasks for the conversation. When `todayEndMs` is
+// provided, future-dated rows (`due >= todayEndMs`) are filtered out so
+// callers see only overdue + due-today + no-due. The TZ-sensitive
+// boundary is computed in the host process (slice 2 surfaces it from
+// the host runtime so Convex stays TZ-agnostic).
 export const listOpen = query({
-  args: { conversationId: v.string() },
+  args: {
+    conversationId: v.string(),
+    todayEndMs: v.optional(v.number()),
+  },
   handler: async (ctx, args) => {
-    return await ctx.db
+    const all = await ctx.db
       .query("tasks")
       .withIndex("by_conversation_status", (q) =>
         q.eq("conversationId", args.conversationId).eq("status", "open"),
       )
       .order("asc")
       .collect();
+    if (args.todayEndMs === undefined) return all;
+    const cutoff = args.todayEndMs;
+    return all.filter((t) => t.due === undefined || t.due < cutoff);
   },
 });
 
@@ -57,6 +72,27 @@ export const markClosed = mutation({
       status: "closed",
       closedAt: Date.now(),
     });
+    return t._id;
+  },
+});
+
+export const update = mutation({
+  args: {
+    taskId: v.string(),
+    description: v.optional(v.string()),
+    due: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const t = await ctx.db
+      .query("tasks")
+      .withIndex("by_task_id", (q) => q.eq("taskId", args.taskId))
+      .unique();
+    if (!t) return null;
+    const patch: { description?: string; due?: number } = {};
+    if (args.description !== undefined) patch.description = args.description;
+    if (args.due !== undefined) patch.due = args.due;
+    if (Object.keys(patch).length === 0) return t._id;
+    await ctx.db.patch(t._id, patch);
     return t._id;
   },
 });

--- a/server/interaction-agent.ts
+++ b/server/interaction-agent.ts
@@ -33,7 +33,7 @@ Your only tools:
 - recall / write_memory (durable memory for this user)
 - spawn_agent (dispatches a sub-agent that CAN touch the world)
 - create_automation / list_automations / toggle_automation / delete_automation
-- create_task / list_tasks / mark_done (TODO list + reminders)
+- create_task / list_tasks / mark_done / update_task (TODO list + reminders)
 - list_drafts / send_draft / reject_draft
 - get_config / set_model / list_integrations / search_composio_catalog / inspect_toolkit (self-inspection)
 
@@ -93,9 +93,15 @@ Tasks (TODO list / reminders):
 - Triggers for create_task: "anota", "me lembra", "tenho que", "preciso", "registra", "não esquece de me lembrar".
 - 1-vs-N rule: if the user dumps several SEMANTICALLY INDEPENDENT items in one message ("ligar pro dentista, mandar email pro Pedro, comprar passagem"), call create_task ONCE PER ITEM. If the items are parts of one logical action ("anota: comprar pão, leite e ovos" — one shopping trip), call create_task ONCE with everything inline. In ambiguous cases, ask.
 - Reply format after creation: when N=1 → "✓ Anotei: <description>" inline. When N>1 → "✓ Anotei N:" then a bullet list with "• <description>" per task.
-- For listing ("lista", "quais minhas tarefas?", "o que tem aberto?"): call list_tasks. The tool returns numbered lines with "(id=...)" embedded. When relaying, OMIT the "(id=...)" parts — show only the number and description, e.g. "1. ligar pro dentista".
-- For closing ("feito a 1", "feito o do dentista", "esquece a 4", "remove a 4", "já liguei pro dentista", "concluí a 2"): resolve to a taskId by reading the most recent list_tasks output you have or by calling list_tasks first, then call mark_done with the resolved taskId. Done and dismiss/remove both map to mark_done in v1 — there is no separate dismiss state.
-- This is slice 1 — there are no due dates, no nag scheduler, no snooze, no edits. If the user asks for any of those, say it's coming soon.
+- Prazos (due): when the user names a deadline, pass it to create_task / update_task as ISO in the user's local time.
+  - Date-only ("até sexta", "amanhã", "antes de domingo", "dia 12") → emit "YYYY-MM-DD" with NO time part. The runtime treats this as "any time that day".
+  - Exact moment ("quinta às 14h", "amanhã às 9 da noite", "hoje 18:30") → emit "YYYY-MM-DDTHH:MM" with NO timezone offset. The runtime interprets it in host TZ.
+  - No deadline mentioned → omit \`due\`.
+  - Resolve relative phrases ("amanhã", "sexta", "daqui a 2 dias") against the user's current local date. Don't ask for clarification on common phrases.
+- For listing ("lista", "quais minhas tarefas?", "o que tem aberto?"): call list_tasks. The tool already filters to overdue + due-today + sem-prazo, in that order. Lines look like "N. <description> [(atrasada)] (id=...)". When relaying, OMIT the "(id=...)" part but KEEP "(atrasada)" so the user sees what's late.
+- For closing ("feito a 1", "feito o do dentista", "esquece a 4", "remove a 4", "já liguei pro dentista", "concluí a 2"): resolve to a taskId via the most recent list_tasks output (or call list_tasks first), then call mark_done. Done and dismiss/remove both map to mark_done in v1 — there is no separate dismiss state.
+- For edits ("renomeia a 1 pra X", "muda prazo da 2 pra sexta", "antecipa a 3 pra amanhã às 14h"): resolve reference → taskId, then call update_task with \`description\` and/or \`due\` (same ISO convention as create_task). At least one of the two fields must be set.
+- Nags aren't wired yet, so Boop is silent between turns. If the user expects a ping ("me avisa às 14h"), still register the prazo, but be honest that proactive reminders arrive in a future update.
 - DON'T preface tool calls with narration ("I'll create three tasks...", "Let me check the current list..."). Just call the tool and reply with the result, in Portuguese.
 
 Drafts:
@@ -282,6 +288,7 @@ export async function handleUserMessage(opts: HandleOpts): Promise<string> {
           "mcp__boop-tasks__create_task",
           "mcp__boop-tasks__list_tasks",
           "mcp__boop-tasks__mark_done",
+          "mcp__boop-tasks__update_task",
           "mcp__boop-draft-decisions__list_drafts",
           "mcp__boop-draft-decisions__send_draft",
           "mcp__boop-draft-decisions__reject_draft",

--- a/server/task-tools.ts
+++ b/server/task-tools.ts
@@ -7,6 +7,31 @@ function randomId(prefix: string): string {
   return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
+// Convention: bare YYYY-MM-DD means "midnight in host TZ" (date-only).
+// Anything with a time component (and optional offset) is parsed by the
+// platform — V8 interprets `YYYY-MM-DDTHH:MM` (no offset) as host-local
+// time. Dispatcher emits one of these shapes; everything else throws.
+function parseDueIso(iso: string): number {
+  const dateOnly = iso.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (dateOnly) {
+    return new Date(
+      Number(dateOnly[1]),
+      Number(dateOnly[2]) - 1,
+      Number(dateOnly[3]),
+    ).getTime();
+  }
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) {
+    throw new Error(`Invalid due value: ${iso}`);
+  }
+  return ms;
+}
+
+function todayBoundsHostTz(now: Date = new Date()): { start: number; end: number } {
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  return { start, end: start + 86_400_000 };
+}
+
 export function createTaskMcp(conversationId: string) {
   return createSdkMcpServer({
     name: "boop-tasks",
@@ -20,24 +45,34 @@ Call ONCE per semantically independent task. If the user dumps several distinct 
 
 Triggers from the user: "anota", "me lembra", "tenho que", "preciso", "registra", "não esquece de me lembrar".
 
-This is slice 1 — no due dates, no nags. Just description.`,
+Optional \`due\`: ISO date or datetime in host time. Use \`YYYY-MM-DD\` for a bare date ("até sexta", "amanhã") — that means "any time that day". Use \`YYYY-MM-DDTHH:MM\` (no zone) for an exact moment ("quinta às 14h"). Omit \`due\` when the user gave no deadline.`,
         {
           description: z
             .string()
             .describe("What the task is, in plain language, in the user's voice."),
+          due: z
+            .string()
+            .optional()
+            .describe(
+              "ISO date (YYYY-MM-DD) for date-only, or ISO datetime (YYYY-MM-DDTHH:MM) for an exact moment. Omit when no deadline was given.",
+            ),
         },
         async (args) => {
           const taskId = randomId("tk");
+          const dueMs = args.due !== undefined ? parseDueIso(args.due) : undefined;
           await convex.mutation(api.tasks.create, {
             taskId,
             conversationId,
             description: args.description,
+            ...(dueMs !== undefined ? { due: dueMs } : {}),
           });
+          const dueNote =
+            dueMs !== undefined ? ` (due=${new Date(dueMs).toISOString()})` : "";
           return {
             content: [
               {
                 type: "text" as const,
-                text: `Created task ${taskId}: ${args.description}`,
+                text: `Created task ${taskId}: ${args.description}${dueNote}`,
               },
             ],
           };
@@ -46,18 +81,36 @@ This is slice 1 — no due dates, no nags. Just description.`,
 
       tool(
         "list_tasks",
-        `List all OPEN tasks for this conversation, with their IDs.
+        `List OPEN tasks for this conversation, filtered to overdue + due-today + no-due. Future-dated tasks are hidden until the day arrives.
 
-Returns numbered lines: "N. <description> (id=<taskId>)". When relaying to the user, OMIT the "(id=...)" parts — show only the number and description.`,
+Order: overdue first (oldest due first), then due-today (chronological), then no-due (creation order). Overdue rows are marked "(atrasada)".
+
+Returns numbered lines: "N. <description> [(atrasada)] (id=<taskId>)". When relaying to the user, OMIT the "(id=...)" parts — show only the number, description, and the "(atrasada)" marker when present.`,
         {},
         async () => {
-          const list = await convex.query(api.tasks.listOpen, { conversationId });
+          const { start: todayStart, end: todayEnd } = todayBoundsHostTz();
+          const list = await convex.query(api.tasks.listOpen, {
+            conversationId,
+            todayEndMs: todayEnd,
+          });
           if (list.length === 0) {
             return { content: [{ type: "text" as const, text: "No open tasks." }] };
           }
-          const lines = list.map(
-            (t, i) => `${i + 1}. ${t.description} (id=${t.taskId})`,
-          );
+          const overdue = list
+            .filter((t) => t.due !== undefined && t.due < todayStart)
+            .sort((a, b) => (a.due ?? 0) - (b.due ?? 0));
+          const today = list
+            .filter((t) => t.due !== undefined && t.due >= todayStart && t.due < todayEnd)
+            .sort((a, b) => (a.due ?? 0) - (b.due ?? 0));
+          const noDue = list
+            .filter((t) => t.due === undefined)
+            .sort((a, b) => a.createdAt - b.createdAt);
+          const ordered = [...overdue, ...today, ...noDue];
+          const lines = ordered.map((t, i) => {
+            const isOverdue = t.due !== undefined && t.due < todayStart;
+            const marker = isOverdue ? " (atrasada)" : "";
+            return `${i + 1}. ${t.description}${marker} (id=${t.taskId})`;
+          });
           return { content: [{ type: "text" as const, text: lines.join("\n") }] };
         },
       ),
@@ -77,6 +130,69 @@ Resolve "feito a 1" / "feito o do dentista" / "esquece a 4" / "remove a 4" to a 
               {
                 type: "text" as const,
                 text: id ? `Closed task ${args.taskId}.` : `Task ${args.taskId} not found.`,
+              },
+            ],
+          };
+        },
+      ),
+
+      tool(
+        "update_task",
+        `Edit a task's description and/or prazo.
+
+Triggers: "renomeia a 1 pra X", "muda prazo da 2 pra sexta", "antecipa a 3 pra amanhã", "adia a 1 pra quinta às 14h".
+
+Resolve the user's numeric or fuzzy reference to a taskId via the most recent list_tasks output (or by calling list_tasks first). Pass at least one of \`description\` or \`due\`. \`due\` follows the same ISO convention as create_task: \`YYYY-MM-DD\` for date-only, \`YYYY-MM-DDTHH:MM\` for a precise moment.`,
+        {
+          taskId: z.string().describe("The taskId to update."),
+          description: z
+            .string()
+            .optional()
+            .describe("New description; omit to leave the description unchanged."),
+          due: z
+            .string()
+            .optional()
+            .describe(
+              "New ISO date or datetime; omit to leave the prazo unchanged.",
+            ),
+        },
+        async (args) => {
+          if (args.description === undefined && args.due === undefined) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: "Nothing to update — provide description and/or due.",
+                },
+              ],
+            };
+          }
+          const dueMs = args.due !== undefined ? parseDueIso(args.due) : undefined;
+          const id = await convex.mutation(api.tasks.update, {
+            taskId: args.taskId,
+            ...(args.description !== undefined ? { description: args.description } : {}),
+            ...(dueMs !== undefined ? { due: dueMs } : {}),
+          });
+          if (!id) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `Task ${args.taskId} not found.`,
+                },
+              ],
+            };
+          }
+          const changed: string[] = [];
+          if (args.description !== undefined)
+            changed.push(`description="${args.description}"`);
+          if (dueMs !== undefined)
+            changed.push(`due=${new Date(dueMs).toISOString()}`);
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Updated task ${args.taskId}: ${changed.join(", ")}`,
               },
             ],
           };


### PR DESCRIPTION
Closes #10.

## Summary

Slice 2 of the tasks system per PRD #8. Adds prazo awareness end-to-end: schema, Convex CRUD, MCP tool surface, dispatcher prompt. The dispatcher now parses natural-language dates into ISO and the runtime stores them as ms. Listing filters down to overdue + due-today + no-due; future-dated rows hide until they become today. Editing description and prazo is supported via a new `update_task` tool. Still silent — no nags.

## What changed

- `convex/schema.ts` — `tasks.due: optional<v.number()>` (ms timestamp).
- `convex/tasks.ts`
  - `create` accepts optional `due`.
  - `listOpen` accepts optional `todayEndMs`; when set, filters out future-dated rows. The TZ-sensitive boundary is computed in the host process so Convex stays TZ-agnostic.
  - New `update` mutation patches `description` and/or `due`.
- `server/task-tools.ts`
  - New `parseDueIso` helper. Bare `YYYY-MM-DD` is parsed as midnight host TZ (date-only convention); anything with a time component goes through `Date.parse` (V8 interprets `YYYY-MM-DDTHH:MM` without a zone as host-local).
  - `create_task` accepts optional ISO `due`.
  - `list_tasks` computes today's bounds in host TZ, asks Convex to filter out future-dated rows, then sorts overdue (oldest first) → due-today (chronological) → no-due (creation order). Overdue rows carry an `(atrasada)` marker.
  - New `update_task` tool with the same ISO convention.
- `server/interaction-agent.ts` — Tasks block of the dispatcher prompt extended with a Prazos rule (date-only vs datetime), updated listing description, edit verbs for `update_task`, drops the slice-1 "no due, no edits" disclaimer. Adds `update_task` to `allowedTools`.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean.
- [x] `pnpm exec convex dev --once` pushes the schema cleanly (new `due` field, new `update` mutation).
- [ ] Manual smoke test on the dev deploy:
  - "me lembra de ligar pro dentista quinta às 14h" → task created with the exact datetime.
  - "anota: comprar passagem antes de domingo" → task created with date-only due.
  - "anota: comprar pão" → task created with no due.
  - "lista" → returns overdue → due-today → no-due, with `(atrasada)` markers.
  - "muda prazo da 1 pra sexta" → `update_task` called, prazo updated.
  - "renomeia a 2 pra X" → `update_task` called, description updated.
  - Future-dated task created, then `list_tasks` → hidden until the day arrives.
- [ ] Live Telegram smoke (deferred until merged + redeployed).

## Out of scope (per PRD #8)

- Nag scheduler → slice 3 (#12)
- Reply-to-nag → slice 4 (#13)
- Snooze + reopen → slice 5 (#14)
- Sub-items → slice 6 (#11)
- Cleanup sweep → slice 7 (#15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)