### PR TITLE
ci(deploy): pin HOME/USER/LOGNAME for pm2 --update-env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,6 +94,14 @@ jobs:
           echo "[2/3] pnpm install --frozen-lockfile (as $APP_USER)"
           sudo -u "$APP_USER" -H bash -c "cd '$INSTALL_DIR' && CI=true pnpm install --frozen-lockfile"
           echo "[3/3] pm2 restart $PM2_PROCESS"
-          pm2 restart "$PM2_PROCESS" --update-env
-          pm2 save
+          # Override HOME/USER/LOGNAME so pm2 --update-env stamps the
+          # spawned process with the app user's identity instead of
+          # root's. PM2_HOME pins the daemon location so pm2 still
+          # talks to the existing root-owned daemon (where paizao lives).
+          # Without this, the spawned `claude` subprocess from the
+          # @anthropic-ai/claude-agent-sdk reads OAuth credentials from
+          # /root/.claude and exits with code 1.
+          HOME="/home/$APP_USER" USER="$APP_USER" LOGNAME="$APP_USER" PM2_HOME=/root/.pm2 \
+            pm2 restart "$PM2_PROCESS" --update-env
+          PM2_HOME=/root/.pm2 pm2 save
           REMOTE


### PR DESCRIPTION
## Summary

Fixes a regression introduced when the auto-deploy workflow first ran. After every deploy, the boop server (`paizao`) was being restarted with `HOME=/root`, `USER=root`, `LOGNAME=root` because:

1. The SSH session runs as `root`.
2. `pm2 restart paizao --update-env` reads from the current shell env and stamps it onto the restarted process.
3. The boop server, forked as user `boop`, inherits HOME=/root anyway because pm2 wrote that into its env table.
4. The `@anthropic-ai/claude-agent-sdk` spawns the `claude` CLI as a child process. The CLI reads OAuth credentials from `$HOME/.claude/.credentials.json` and tries to refresh the plugins marketplace under `$HOME/.claude/plugins/`. With `HOME=/root`:
   - credentials file doesn't exist
   - `mkdir /root/.claude/plugins/...` fails with `permission denied`
   - CLI exits with code 1
   - SDK surfaces `Claude Code process exited with code 1`
   - dispatcher's `try { ... query() ... }` block falls through to `"Foi mal — tive um erro processando isso. Tenta de novo daqui a pouco."`

The bot was effectively unusable for ~6 hours after the previous deploy.

## Diagnosis

```
$ pm2 env 3 | grep -E "^HOME |^USER|^LOGNAME"
USER: root
HOME: /root
LOGNAME: root
```

```
$ tail /home/boop/.claude/debug/<latest>.txt
[ERROR] Failed to refresh marketplace claude-plugins-official: ...
fatal: could not create leading directories of
'/root/.claude/plugins/marketplaces/claude-plugins-official': Permission denied
```

## Fix

Explicitly set `HOME=/home/$APP_USER USER=$APP_USER LOGNAME=$APP_USER` on the `pm2 restart --update-env` line. `PM2_HOME=/root/.pm2` is pinned so pm2 still talks to the existing root-owned daemon instead of trying to spin up a new one under boop's home (which would orphan the running paizao process).

```yaml
HOME="/home/$APP_USER" USER="$APP_USER" LOGNAME="$APP_USER" PM2_HOME=/root/.pm2 \
  pm2 restart "$PM2_PROCESS" --update-env
PM2_HOME=/root/.pm2 pm2 save
```

## Manual fix already applied to prod

I ran the equivalent restart by hand (`HOME=/home/boop USER=boop LOGNAME=boop PM2_HOME=/root/.pm2 pm2 restart paizao --update-env && pm2 save`) so the bot is responsive again right now. This PR makes the fix permanent for future deploys.

## Test plan

- [ ] Merge.
- [ ] Watch the auto-deploy workflow run; expect green.
- [ ] On the VPS: `pm2 env 3 | grep -E "^HOME|^USER|^LOGNAME"` should show `boop`/`/home/boop`/`boop`.
- [ ] Send a Telegram message; expect a real reply (not the generic error fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)