### PR TITLE
feat(automations): slice 1 — watcher tracer (notifyOnlyOnChange + diff-based notification)

### DIFF
--- a/convex/automations.ts
+++ b/convex/automations.ts
@@ -11,6 +11,7 @@ export const create = mutation({
     conversationId: v.optional(v.string()),
     notifyConversationId: v.optional(v.string()),
     nextRunAt: v.optional(v.number()),
+    notifyOnlyOnChange: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const existing = await ctx.db
@@ -148,5 +149,21 @@ export const recentRuns = query({
         .take(limit);
     }
     return await ctx.db.query("automationRuns").order("desc").take(limit);
+  },
+});
+
+export const updateSnapshot = mutation({
+  args: {
+    automationId: v.string(),
+    lastSnapshot: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const auto = await ctx.db
+      .query("automations")
+      .withIndex("by_automation_id", (q) => q.eq("automationId", args.automationId))
+      .unique();
+    if (!auto) return null;
+    await ctx.db.patch(auto._id, { lastSnapshot: args.lastSnapshot });
+    return auto._id;
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -155,6 +155,8 @@ export default defineSchema({
     notifyConversationId: v.optional(v.string()),
     lastRunAt: v.optional(v.number()),
     nextRunAt: v.optional(v.number()),
+    notifyOnlyOnChange: v.optional(v.boolean()),
+    lastSnapshot: v.optional(v.string()),
     createdAt: v.number(),
   })
     .index("by_automation_id", ["automationId"])

--- a/server/automation-tools.ts
+++ b/server/automation-tools.ts
@@ -46,6 +46,13 @@ Integrations available: ${integrationHint}`,
             .optional()
             .default(true)
             .describe("If true, send the result to this conversation when it runs."),
+          notifyOnlyOnChange: z
+            .boolean()
+            .optional()
+            .default(false)
+            .describe(
+              "If true, run as a watcher: only notify when new items appear since the last tick. First run stores a baseline without notifying. Useful for monitoring lists (e.g. new emails, new events).",
+            ),
         },
         async (args) => {
           const validation = validateSchedule(args.schedule);
@@ -70,6 +77,7 @@ Integrations available: ${integrationHint}`,
             conversationId,
             notifyConversationId: args.notify ? conversationId : undefined,
             nextRunAt,
+            notifyOnlyOnChange: args.notifyOnlyOnChange,
           });
           const nextStr = nextRunAt ? new Date(nextRunAt).toLocaleString() : "unknown";
           return {

--- a/server/automations.ts
+++ b/server/automations.ts
@@ -9,6 +9,20 @@ function randomId(prefix: string): string {
   return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
+const SNAPSHOT_MAX_CHARS = 16384;
+
+export function normalizeSnapshot(raw: string): string[] {
+  return raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+export function diffAdditions(prev: string[], curr: string[]): string[] {
+  const prevSet = new Set(prev);
+  return curr.filter((line) => !prevSet.has(line));
+}
+
 export function nextRunFor(schedule: string): number | null {
   try {
     const c = new Cron(schedule, { paused: true });
@@ -36,6 +50,8 @@ async function runAutomation(a: {
   schedule: string;
   conversationId?: string;
   notifyConversationId?: string;
+  notifyOnlyOnChange?: boolean;
+  lastSnapshot?: string;
 }): Promise<void> {
   const runId = randomId("run");
   await convex.mutation(api.automations.createRun, {
@@ -45,33 +61,99 @@ async function runAutomation(a: {
   broadcast("automation_started", { automationId: a.automationId, runId, name: a.name });
 
   try {
-    const res = await spawnExecutionAgent({
-      task: `AUTOMATION "${a.name}": ${a.task}`,
-      integrations: a.integrations,
-      conversationId: a.conversationId,
-      name: `auto:${a.name}`,
-    });
-    await convex.mutation(api.automations.updateRun, {
-      runId,
-      status: res.status === "completed" ? "completed" : "failed",
-      result: res.result,
-      agentId: res.agentId,
-    });
-
-    if (a.notifyConversationId && res.result) {
-      if (a.notifyConversationId.startsWith("telegram:")) {
-        const chatId = a.notifyConversationId.slice("telegram:".length);
-        const preamble = `[${a.name}]\n\n`;
-        await sendTelegramMessage(chatId, preamble + res.result);
-      }
-      await convex.mutation(api.messages.send, {
-        conversationId: a.notifyConversationId,
-        role: "assistant",
-        content: `[${a.name}]\n\n${res.result}`,
+    if (a.notifyOnlyOnChange) {
+      const watcherTask =
+        `AUTOMATION "${a.name}": ${a.task}\n\n` +
+        `Retorne uma lista, um item por linha. Formato consistente, sem variação. Sem comentários, sem cabeçalho, sem rodapé.`;
+      const res = await spawnExecutionAgent({
+        task: watcherTask,
+        integrations: a.integrations,
+        conversationId: a.conversationId,
+        name: `auto:${a.name}`,
+        model: "claude-haiku-4-5",
+        temperature: 0,
       });
-    }
 
-    broadcast("automation_completed", { automationId: a.automationId, runId });
+      if (res.status !== "completed" || !res.result) {
+        await convex.mutation(api.automations.updateRun, {
+          runId,
+          status: "failed",
+          result: res.result,
+          agentId: res.agentId,
+          error: res.status !== "completed" ? "agent did not complete" : "empty result",
+        });
+        broadcast("automation_failed", { automationId: a.automationId, runId });
+      } else {
+        await convex.mutation(api.automations.updateRun, {
+          runId,
+          status: "completed",
+          result: res.result,
+          agentId: res.agentId,
+        });
+
+        const currLines = normalizeSnapshot(res.result);
+        const currText = currLines.join("\n").slice(0, SNAPSHOT_MAX_CHARS);
+
+        if (a.lastSnapshot == null) {
+          await convex.mutation(api.automations.updateSnapshot, {
+            automationId: a.automationId,
+            lastSnapshot: currText,
+          });
+        } else {
+          const prevLines = normalizeSnapshot(a.lastSnapshot);
+          const additions = diffAdditions(prevLines, currLines);
+
+          await convex.mutation(api.automations.updateSnapshot, {
+            automationId: a.automationId,
+            lastSnapshot: currText,
+          });
+
+          if (additions.length > 0 && a.notifyConversationId) {
+            const body =
+              `[${a.name}]\n` + additions.map((line) => `Novo: ${line}`).join("\n");
+            if (a.notifyConversationId.startsWith("telegram:")) {
+              const chatId = a.notifyConversationId.slice("telegram:".length);
+              await sendTelegramMessage(chatId, body);
+            }
+            await convex.mutation(api.messages.send, {
+              conversationId: a.notifyConversationId,
+              role: "assistant",
+              content: body,
+            });
+          }
+        }
+
+        broadcast("automation_completed", { automationId: a.automationId, runId });
+      }
+    } else {
+      const res = await spawnExecutionAgent({
+        task: `AUTOMATION "${a.name}": ${a.task}`,
+        integrations: a.integrations,
+        conversationId: a.conversationId,
+        name: `auto:${a.name}`,
+      });
+      await convex.mutation(api.automations.updateRun, {
+        runId,
+        status: res.status === "completed" ? "completed" : "failed",
+        result: res.result,
+        agentId: res.agentId,
+      });
+
+      if (a.notifyConversationId && res.result) {
+        if (a.notifyConversationId.startsWith("telegram:")) {
+          const chatId = a.notifyConversationId.slice("telegram:".length);
+          const preamble = `[${a.name}]\n\n`;
+          await sendTelegramMessage(chatId, preamble + res.result);
+        }
+        await convex.mutation(api.messages.send, {
+          conversationId: a.notifyConversationId,
+          role: "assistant",
+          content: `[${a.name}]\n\n${res.result}`,
+        });
+      }
+
+      broadcast("automation_completed", { automationId: a.automationId, runId });
+    }
   } catch (err) {
     await convex.mutation(api.automations.updateRun, {
       runId,
@@ -94,7 +176,6 @@ export async function tickAutomations(): Promise<void> {
   const now = Date.now();
   const due = all.filter((a) => a.nextRunAt !== undefined && a.nextRunAt <= now);
   for (const a of due) {
-    // fire-and-forget so one slow automation doesn't block others
     runAutomation({
       automationId: a.automationId,
       name: a.name,
@@ -103,6 +184,8 @@ export async function tickAutomations(): Promise<void> {
       schedule: a.schedule,
       conversationId: a.conversationId,
       notifyConversationId: a.notifyConversationId,
+      notifyOnlyOnChange: a.notifyOnlyOnChange,
+      lastSnapshot: a.lastSnapshot,
     }).catch((err) => console.error("[automations] run error", err));
   }
 }

--- a/server/execution-agent.ts
+++ b/server/execution-agent.ts
@@ -89,6 +89,10 @@ export interface SpawnOptions {
   integrations: string[];
   conversationId?: string;
   name?: string;
+  /** Override the model used for this spawn. Defaults to the runtime model. */
+  model?: string;
+  /** Override the sampling temperature. Defaults to the model's own default. */
+  temperature?: number;
 }
 
 export interface SpawnResult {
@@ -146,13 +150,15 @@ export async function spawnExecutionAgent(opts: SpawnOptions): Promise<SpawnResu
   let status: "completed" | "failed" | "cancelled" = "completed";
   let errorMsg: string | undefined;
 
-  const requestedModel = await getRuntimeModel();
+  const runtimeModel = await getRuntimeModel();
+  const requestedModel = opts.model ?? runtimeModel;
   try {
     for await (const msg of query({
       prompt: opts.task,
       options: {
         systemPrompt: EXECUTION_SYSTEM,
         model: requestedModel,
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
         mcpServers,
         allowedTools,
         // Load .claude/skills/ so the model can invoke SKILL.md playbooks. Without


### PR DESCRIPTION
Closes #20. Tracer-bullet slice of the watcher feature (parent PRD: #6).

## What's in here

End-to-end watcher path via the existing MCP `create_automation` tool:

- `convex/schema.ts`: two optional fields on `automations` — `notifyOnlyOnChange: boolean` and `lastSnapshot: string`.
- `convex/automations.ts`: `create` accepts the two new fields; new `updateSnapshot` mutation.
- `server/execution-agent.ts`: `SpawnOptions` gains optional `model` and `temperature` overrides (non-watcher callers unaffected).
- `server/automations.ts`: pure helpers `normalizeSnapshot` and `diffAdditions` (inline, no new file). `runAutomation` gains a watcher branch when `notifyOnlyOnChange === true` — pinned Haiku at temp=0, format-discipline appendix on the task, silent baseline on first tick, additions-only `[name]\nNovo: <line>` notification, snapshot truncated to 16KB. Failure path keeps `lastSnapshot` untouched. Standard branch behavior unchanged.
- `server/automation-tools.ts`: `create_automation` accepts optional `notifyOnlyOnChange`, forwards to Convex.

## Out of scope

Dispatcher detection of natural-language watcher requests (#21) and the `(watcher)` marker in `list_automations` (#22) ship in stacked follow-ups.

## Test plan

- [ ] `pnpm exec convex codegen` succeeds (schema validates).
- [ ] Manually create a watcher via MCP with `notifyOnlyOnChange: true`. Confirm first tick is silent (snapshot stored, no Telegram message).
- [ ] On second tick with new lines in the result, confirm a `Novo: <line>` Telegram message arrives. Unchanged ticks produce no message.
- [ ] Force a spawn failure (e.g. invalid task) — confirm `lastSnapshot` is NOT updated and no notification fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)