### PR TITLE
feat(automations): slice 3 — (watcher) marker in list_automations

### DIFF
--- a/server/automation-tools.ts
+++ b/server/automation-tools.ts
@@ -105,7 +105,7 @@ Integrations available: ${integrationHint}`,
           }
           const lines = mine.map(
             (a) =>
-              `• [${a.automationId}] ${a.enabled ? "●" : "○"} "${a.name}" — ${a.schedule} — ${a.task}`,
+              `• [${a.automationId}] ${a.enabled ? "●" : "○"} "${a.name}" — ${a.schedule} — ${a.task}${a.notifyOnlyOnChange === true ? " (watcher)" : ""}`,
           );
           return { content: [{ type: "text" as const, text: lines.join("\n") }] };
         },


### PR DESCRIPTION
Closes #22. Stacked on top of #23.

## What's in here

One-line change to `server/automation-tools.ts`: rows where `notifyOnlyOnChange === true` render with a trailing `(watcher)` marker in `list_automations`. Regular automations are unchanged. `toggle_automation` and `delete_automation` are untouched.

## Test plan

- [ ] Create one watcher and one regular automation via MCP.
- [ ] Call `list_automations`. Watcher row ends with `(watcher)`; regular row does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)