### PR TITLE
feat(banking): SQLite skeleton + pluggy_items and finance_audit_log tables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,11 @@ RP_ORIGIN=https://paizao.jardim.dev.br
 # /opt/boop-agent in prod).
 # PASSKEY_STORE=
 
+# Optional: override the Banking BR SQLite path. Default resolves to
+# ./data/finance.db against process.cwd(). Lives only on this machine; if lost,
+# downstream caches rebuild from Pluggy on next call.
+# BOOP_FINANCE_DB_PATH=
+
 # Optional local debug convenience. This exposes the token to the Vite debug UI,
 # so only use it for local personal development.
 # VITE_ADMIN_TOKEN=

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "preflight": "node scripts/preflight.mjs",
     "dev": "node scripts/dev.mjs",
     "dev:parallel": "npm-run-all --parallel dev:server dev:convex dev:debug",
-    "dev:server": "npm run preflight && tsx watch server/index.ts",
+    "dev:server": "npm run preflight && NODE_OPTIONS=--experimental-sqlite tsx watch server/index.ts",
     "dev:convex": "convex dev",
     "dev:debug": "vite --config debug/vite.config.ts",
     "build:debug": "vite build --config debug/vite.config.ts",
-    "start": "npm run preflight && tsx server/index.ts",
+    "start": "npm run preflight && NODE_OPTIONS=--experimental-sqlite tsx server/index.ts",
     "deploy:convex": "convex deploy",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -78,9 +78,15 @@ const NOISE_TRIGGERS = [
 const STACK_LINE = /^\s+at\s/;
 
 function run(name, cmd, args, readyPattern) {
+  const env = { ...process.env, FORCE_COLOR: "1" };
+  if (name === "server") {
+    env.NODE_OPTIONS = [env.NODE_OPTIONS, "--experimental-sqlite"]
+      .filter(Boolean)
+      .join(" ");
+  }
   const child = spawn(cmd, args, {
     cwd: root,
-    env: { ...process.env, FORCE_COLOR: "1" },
+    env,
   });
   const prefix = `${C[name]}${name.padEnd(6)}${C.reset} │ `;
   let buf = "";

--- a/server/finance/db.ts
+++ b/server/finance/db.ts
@@ -1,0 +1,27 @@
+import { DatabaseSync } from "node:sqlite";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import { runMigrations } from "./migrations/runner.js";
+
+let instance: DatabaseSync | null = null;
+
+function resolveDbPath(): string {
+  const override = process.env.BOOP_FINANCE_DB_PATH?.trim();
+  if (override) return path.resolve(override);
+  return path.resolve(process.cwd(), "data", "finance.db");
+}
+
+export function getFinanceDb(): DatabaseSync {
+  if (instance) return instance;
+  const dbPath = resolveDbPath();
+  mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  const { applied } = runMigrations(db);
+  if (applied.length > 0) {
+    console.log(`[finance] applied migrations: ${applied.join(", ")}`);
+  }
+  instance = db;
+  return db;
+}

--- a/server/finance/migrations/001_initial.sql
+++ b/server/finance/migrations/001_initial.sql
@@ -1,0 +1,18 @@
+CREATE TABLE pluggy_items (
+  item_id TEXT PRIMARY KEY,
+  alias TEXT NOT NULL,
+  connector_id INTEGER,
+  status TEXT NOT NULL DEFAULT 'unknown',
+  last_sync_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE finance_audit_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source TEXT NOT NULL,
+  action TEXT NOT NULL,
+  payload TEXT,
+  result TEXT,
+  duration_ms INTEGER,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);

--- a/server/finance/migrations/runner.ts
+++ b/server/finance/migrations/runner.ts
@@ -1,0 +1,51 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { DatabaseSync } from "node:sqlite";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+function ensureMetaTable(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS _meta_migrations (
+      version TEXT PRIMARY KEY,
+      applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    );
+  `);
+}
+
+function appliedVersions(db: DatabaseSync): Set<string> {
+  const rows = db.prepare("SELECT version FROM _meta_migrations").all() as { version: string }[];
+  return new Set(rows.map((r) => r.version));
+}
+
+function discoverMigrations(): { version: string; file: string }[] {
+  const entries = readdirSync(here)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+  return entries.map((file) => ({
+    version: file.replace(/\.sql$/, ""),
+    file: path.join(here, file),
+  }));
+}
+
+export function runMigrations(db: DatabaseSync): { applied: string[] } {
+  ensureMetaTable(db);
+  const already = appliedVersions(db);
+  const applied: string[] = [];
+  for (const { version, file } of discoverMigrations()) {
+    if (already.has(version)) continue;
+    const sql = readFileSync(file, "utf8");
+    db.exec("BEGIN");
+    try {
+      db.exec(sql);
+      db.prepare("INSERT INTO _meta_migrations (version) VALUES (?)").run(version);
+      db.exec("COMMIT");
+    } catch (err) {
+      db.exec("ROLLBACK");
+      throw new Error(`migration ${version} failed: ${(err as Error).message}`);
+    }
+    applied.push(version);
+  }
+  return { applied };
+}

--- a/server/finance/routes.ts
+++ b/server/finance/routes.ts
@@ -1,0 +1,38 @@
+import express from "express";
+import { getFinanceDb } from "./db.js";
+
+export function createFinanceRouter(): express.Router {
+  const router = express.Router();
+
+  router.get("/items", (_req, res) => {
+    try {
+      const db = getFinanceDb();
+      const rows = db
+        .prepare(
+          "SELECT item_id, alias, connector_id, status, last_sync_at, created_at FROM pluggy_items ORDER BY created_at DESC",
+        )
+        .all();
+      res.json({ items: rows });
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  router.get("/audit", (req, res) => {
+    try {
+      const limitRaw = typeof req.query.limit === "string" ? Number(req.query.limit) : 50;
+      const limit = Number.isFinite(limitRaw) ? Math.min(Math.max(1, limitRaw), 500) : 50;
+      const db = getFinanceDb();
+      const rows = db
+        .prepare(
+          "SELECT id, source, action, payload, result, duration_ms, created_at FROM finance_audit_log ORDER BY id DESC LIMIT ?",
+        )
+        .all(limit);
+      res.json({ entries: rows });
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  return router;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,8 +19,14 @@ import { adminTokenFromUpgrade, isAdminTokenValid, requireAdminToken } from "./h
 import { ensureProactiveWatcher } from "./proactive-email.js";
 import { preloadLocalModel } from "./embeddings.js";
 import { createMemoryRouter } from "./memory-routes.js";
+import { createFinanceRouter } from "./finance/routes.js";
+import { getFinanceDb } from "./finance/db.js";
 
 async function main() {
+  // Open SQLite + run any pending migrations on boot, so the first finance
+  // request doesn't pay the migrate cost and a missing/unwritable data dir
+  // surfaces immediately instead of inside a tool call.
+  getFinanceDb();
   await loadIntegrations();
   startCleanupLoop();
   startAutomationLoop();
@@ -84,6 +90,7 @@ async function main() {
   apiRouter.use(requireAdminToken);
   apiRouter.use("/composio", createComposioRouter());
   apiRouter.use("/memory", createMemoryRouter());
+  apiRouter.use("/finance", createFinanceRouter());
 
   apiRouter.post("/agents/:id/cancel", (req, res) => {
     const ok = cancelAgent(req.params.id);


### PR DESCRIPTION
## Summary

Closes #26. Foundation slice for Banking BR.

- `server/finance/db.ts` — `node:sqlite` singleton, WAL, migrate-on-init. Default path `data/finance.db`, override via `BOOP_FINANCE_DB_PATH`.
- `server/finance/migrations/runner.ts` — reads `*.sql` lexicographically, applies each in a transaction, tracks applied versions in `_meta_migrations`. Idempotent on second boot.
- `server/finance/migrations/001_initial.sql` — creates `pluggy_items` and `finance_audit_log` per the AC.
- `server/finance/routes.ts` — `GET /api/finance/items` and `GET /api/finance/audit?limit=50` (cap 500), mounted under the existing auth-gated `apiRouter`.
- Boots the DB during `main()` so a missing/unwritable `data/` surfaces immediately rather than inside a tool call.
- `NODE_OPTIONS=--experimental-sqlite` added to `dev:server`, `start`, and the server child spawned by `scripts/dev.mjs`.

## ⚠ Stacked on `feature/passkey-auth`

This branch is based on `feature/passkey-auth` (which adds the `apiRouter`, the `/api` prefix, and the dashboard SPA mount that this slice's AC assumes). Until passkey-auth lands on main, this PR's diff includes all of those changes too. Once passkey-auth is merged, the diff above auto-collapses to just the Banking #26 commit.

Recommended merge order:
1. Land `feature/passkey-auth` first
2. This PR's diff cleans up automatically

## Test plan

- [x] `pnpm typecheck` clean
- [x] Boot from empty data dir: `[finance] applied migrations: 001_initial`, server listening
- [x] Second boot: migration skipped (idempotent)
- [x] `GET /api/finance/items` without token → `401 admin token required`
- [x] `GET /api/finance/items` with `Authorization: Bearer $ADMIN_TOKEN` → `{"items":[]}`
- [x] `GET /api/finance/audit?limit=5` → `{"entries":[]}`
- [x] `PRAGMA journal_mode` returns `wal`; `data/finance.db-wal` and `-shm` files present
- [x] Schema matches AC: `pluggy_items` (item_id PK, alias, connector_id, status, last_sync_at, created_at), `finance_audit_log` (id PK auto, source, action, payload, result, duration_ms, created_at)

🤖 Generated with [Claude Code](https://claude.com/claude-code)