### PR TITLE
feat(stt): Groq Whisper provider for Telegram audio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,16 +54,31 @@ PUBLIC_URL=http://localhost:3456
 # URL with Telegram via setWebhook. Set to "false" to disable this behavior.
 # TELEGRAM_AUTO_WEBHOOK=true
 
-# ---- Telegram voice transcription (optional, local Whisper) ----
-# Set STT_PROVIDER=local to transcribe Telegram voice/audio messages on this
-# machine or VPS. Requires ffmpeg, whisper-cli, and a multilingual Whisper model.
+# ---- Telegram voice transcription (optional) ----
+# STT_PROVIDER selects the engine:
+#   off    — disabled; Telegram voice/audio messages get a placeholder reply.
+#   groq   — Groq Cloud Whisper API. Cheap (~$0.04/h), fast (~10s of audio in
+#            sub-second wall-clock), no system deps. Requires GROQ_API_KEY.
+#            Get a key at https://console.groq.com/keys.
+#   local  — whisper.cpp on this box. Private, no API cost, but CPU-bound.
+#            Requires ffmpeg, whisper-cli, and a Whisper model file.
 STT_PROVIDER=off
+
+# Shared across providers
+WHISPER_LANGUAGE=pt
+TELEGRAM_AUDIO_MAX_BYTES=26214400
+
+# Groq STT (used when STT_PROVIDER=groq)
+# GROQ_API_KEY=
+# GROQ_STT_MODEL=whisper-large-v3-turbo
+# GROQ_STT_LANGUAGE=pt
+# GROQ_STT_TIMEOUT_MS=60000
+
+# Local whisper.cpp (used when STT_PROVIDER=local)
 WHISPER_BIN=whisper-cli
 WHISPER_MODEL=
-WHISPER_LANGUAGE=pt
 FFMPEG_BIN=ffmpeg
 WHISPER_TIMEOUT_MS=120000
-TELEGRAM_AUDIO_MAX_BYTES=26214400
 WHISPER_THREADS=
 WHISPER_USE_GPU=false
 

--- a/server/local-stt.ts
+++ b/server/local-stt.ts
@@ -7,7 +7,12 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_GROQ_TIMEOUT_MS = 60_000;
 const DEFAULT_MAX_BYTES = 25 * 1024 * 1024;
+const DEFAULT_GROQ_MODEL = "whisper-large-v3-turbo";
+const GROQ_TRANSCRIPTIONS_URL = "https://api.groq.com/openai/v1/audio/transcriptions";
+
+type SttProvider = "local" | "groq";
 
 function envInt(name: string, fallback: number): number {
   const raw = process.env[name]?.trim();
@@ -16,25 +21,30 @@ function envInt(name: string, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function rawProvider(): string {
+  return (process.env.STT_PROVIDER ?? "off").trim().toLowerCase();
+}
+
 export function audioTranscriptionEnabled(): boolean {
-  return (process.env.STT_PROVIDER ?? "off").trim().toLowerCase() === "local";
+  const p = rawProvider();
+  return p === "local" || p === "groq";
 }
 
 export function maxAudioBytes(): number {
   return envInt("TELEGRAM_AUDIO_MAX_BYTES", DEFAULT_MAX_BYTES);
 }
 
-function localWhisperConfig() {
-  const provider = (process.env.STT_PROVIDER ?? "off").trim().toLowerCase();
-  if (provider !== "local") {
-    throw new Error(`Unsupported STT_PROVIDER "${provider}". Supported values: local, off.`);
-  }
+function selectedProvider(): SttProvider {
+  const p = rawProvider();
+  if (p === "local" || p === "groq") return p;
+  throw new Error(`Unsupported STT_PROVIDER "${p}". Supported: local, groq, off.`);
+}
 
+function localWhisperConfig() {
   const model = process.env.WHISPER_MODEL?.trim();
   if (!model) {
     throw new Error("WHISPER_MODEL is required for local audio transcription.");
   }
-
   return {
     ffmpegBin: process.env.FFMPEG_BIN?.trim() || "ffmpeg",
     whisperBin: process.env.WHISPER_BIN?.trim() || "whisper-cli",
@@ -46,7 +56,22 @@ function localWhisperConfig() {
   };
 }
 
-export async function transcribeAudioFile(inputPath: string): Promise<string> {
+function groqConfig() {
+  const apiKey = process.env.GROQ_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("GROQ_API_KEY is required for Groq audio transcription.");
+  }
+  return {
+    apiKey,
+    model: process.env.GROQ_STT_MODEL?.trim() || DEFAULT_GROQ_MODEL,
+    // Groq accepts a single primary language hint in ISO-639-1. We reuse
+    // WHISPER_LANGUAGE so users who flip providers don't have to duplicate.
+    language: process.env.GROQ_STT_LANGUAGE?.trim() || process.env.WHISPER_LANGUAGE?.trim() || "pt",
+    timeoutMs: envInt("GROQ_STT_TIMEOUT_MS", DEFAULT_GROQ_TIMEOUT_MS),
+  };
+}
+
+async function transcribeWithLocalWhisper(inputPath: string): Promise<string> {
   const cfg = localWhisperConfig();
   const workDir = await mkdtemp(path.join(tmpdir(), "boop-stt-"));
   const wavPath = path.join(workDir, "audio.wav");
@@ -87,5 +112,53 @@ export async function transcribeAudioFile(inputPath: string): Promise<string> {
     return transcript;
   } finally {
     await rm(workDir, { recursive: true, force: true });
+  }
+}
+
+async function transcribeWithGroq(inputPath: string): Promise<string> {
+  const cfg = groqConfig();
+  const buf = await readFile(inputPath);
+  const filename = path.basename(inputPath) || "audio";
+
+  const form = new FormData();
+  form.append("file", new Blob([new Uint8Array(buf)]), filename);
+  form.append("model", cfg.model);
+  form.append("language", cfg.language);
+  form.append("response_format", "text");
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), cfg.timeoutMs);
+  let res: Response;
+  try {
+    res = await fetch(GROQ_TRANSCRIPTIONS_URL, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${cfg.apiKey}` },
+      body: form,
+      signal: ctrl.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `Groq STT failed: ${res.status} ${res.statusText} ${body.slice(0, 200)}`,
+    );
+  }
+
+  const transcript = (await res.text()).trim();
+  if (!transcript) {
+    throw new Error("Groq returned an empty transcript.");
+  }
+  return transcript;
+}
+
+export async function transcribeAudioFile(inputPath: string): Promise<string> {
+  switch (selectedProvider()) {
+    case "groq":
+      return transcribeWithGroq(inputPath);
+    case "local":
+      return transcribeWithLocalWhisper(inputPath);
   }
 }


### PR DESCRIPTION
## Summary

Adds `STT_PROVIDER=groq` as an alternative to the existing local whisper.cpp path, motivated by the VPS being CPU-bound: `large-v3-turbo-q5_0` clocks ~22x real-time on this 4 vCPU AMD EPYC, so a 30s voice message takes ~10 minutes. Groq's Whisper API runs the same model class on their hardware in sub-second wall-clock for typical voice messages, ~$0.04/h of audio.

The local provider is unchanged for users who prefer self-hosted.

## How it works

- New `transcribeWithGroq()` in `server/local-stt.ts` posts the raw Telegram audio file (typically `.oga`/Opus) directly to `https://api.groq.com/openai/v1/audio/transcriptions` as multipart form-data. No ffmpeg step, no temp wav.
- `audioTranscriptionEnabled()` now returns true for both `local` and `groq`.
- Defaults: model `whisper-large-v3-turbo`, language reused from `WHISPER_LANGUAGE` (so flipping providers doesn't require duplicating config), 60s timeout via `GROQ_STT_TIMEOUT_MS`.

## Configuration

```env
STT_PROVIDER=groq
GROQ_API_KEY=gsk_...
# Optional overrides:
# GROQ_STT_MODEL=whisper-large-v3-turbo
# GROQ_STT_LANGUAGE=pt
# GROQ_STT_TIMEOUT_MS=60000
```

Get a key at https://console.groq.com/keys.

## Test plan

- [x] File typechecks cleanly in isolation (`tsc` over `server/local-stt.ts`)
- [x] Module imports cleanly via tsx, exports preserved (`audioTranscriptionEnabled`, `maxAudioBytes`, `transcribeAudioFile`)
- [ ] After merge + deploy: set `GROQ_API_KEY` + `STT_PROVIDER=groq` in VPS `.env.local`, `pm2 restart paizao --update-env`, send a voice message via Telegram, confirm transcript returns within seconds.

## Pre-existing typecheck noise

`pnpm typecheck` on `main` already fails on `server/composio.ts(481,59)` (unrelated `alias` field type drift). This PR does not touch composio.ts and the noise is pre-existing — see `feature/passkey-auth` commit `a1e70c3` for the pending repair on a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)