### PR TITLE
fix(stt): normalize Telegram .oga to .ogg for Groq upload

### DIFF
--- a/server/local-stt.ts
+++ b/server/local-stt.ts
@@ -118,7 +118,14 @@ async function transcribeWithLocalWhisper(inputPath: string): Promise<string> {
 async function transcribeWithGroq(inputPath: string): Promise<string> {
   const cfg = groqConfig();
   const buf = await readFile(inputPath);
-  const filename = path.basename(inputPath) || "audio";
+  // Groq's allowlist is flac/mp3/mp4/mpeg/mpga/m4a/ogg/opus/wav/webm and it
+  // sniffs the filename extension. Telegram saves voice messages as `.oga`
+  // (the Ogg container with Opus inside) which trips a 400 even though the
+  // bytes are valid. Normalize `.oga` -> `.ogg` for upload only.
+  const ext = path.extname(inputPath).toLowerCase();
+  const safeExt = ext === ".oga" ? ".ogg" : ext;
+  const base = path.basename(inputPath, ext);
+  const filename = (base || "audio") + (safeExt || ".ogg");
 
   const form = new FormData();
   form.append("file", new Blob([new Uint8Array(buf)]), filename);


### PR DESCRIPTION
## Summary

The first real voice message after the Groq STT switch failed in production with:

\`\`\`
Groq STT failed: 400 Bad Request {"error":{"message":"file must be one of the following types: [flac mp3 mp4 mpeg mpga m4a ogg opus wav webm]","type":"invalid_request_error"}}
\`\`\`

Groq's transcription endpoint sniffs the filename extension from the multipart upload and rejects \`.oga\`, even though Telegram voice messages are Ogg+Opus (the same container the allowlisted \`.ogg\` accepts). The local smoke test missed this because it used a synthetic \`.wav\` rather than a real Telegram-shaped file.

## Fix

Normalize the upload-side filename: \`.oga\` becomes \`.ogg\` when handing the file to Groq. Other extensions pass through untouched. The on-disk file is not renamed — only the \`filename\` field of the multipart form changes.

## Test plan

- [x] Generate an Ogg+Opus file with \`.oga\` extension via \`ffmpeg -c:a libopus -b:a 24k\`, confirm \`file\` reports \`Ogg data, Opus audio\`
- [x] \`transcribeAudioFile()\` returns a transcript in 564 ms (vs 400 before)
- [ ] After merge + deploy: send a Telegram voice, confirm transcript and reply land successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)