### PR TITLE
fix(agent): retry + debug-log capture on Claude Code subprocess exits

### DIFF
--- a/server/agent-query.ts
+++ b/server/agent-query.ts
@@ -1,0 +1,106 @@
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+const CLAUDE_DEBUG_DIR = path.join(homedir(), ".claude", "debug");
+const DEFAULT_DEBUG_TAIL_LINES = 30;
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// Pulls the tail of the most recently mtime'd `~/.claude/debug/*.txt` whose
+// mtime is at or after `sinceMs`. The Claude Code SDK writes per-invocation
+// debug logs there but does not surface them via the parent process's stderr,
+// so when a subprocess exits non-zero we have no other window into why.
+async function readLatestSdkDebugTail(
+  sinceMs: number,
+  lines: number = DEFAULT_DEBUG_TAIL_LINES,
+): Promise<string | null> {
+  let entries: string[];
+  try {
+    entries = await readdir(CLAUDE_DEBUG_DIR);
+  } catch {
+    return null;
+  }
+  let best: { path: string; mtime: number } | null = null;
+  for (const name of entries) {
+    if (!name.endsWith(".txt")) continue;
+    const full = path.join(CLAUDE_DEBUG_DIR, name);
+    try {
+      const s = await stat(full);
+      if (!s.isFile() || s.mtimeMs < sinceMs) continue;
+      if (!best || s.mtimeMs > best.mtime) {
+        best = { path: full, mtime: s.mtimeMs };
+      }
+    } catch {
+      // ignore stat failures
+    }
+  }
+  if (!best) return null;
+  try {
+    const text = await readFile(best.path, "utf-8");
+    const tail = text.split("\n").slice(-lines).join("\n");
+    return `${path.basename(best.path)}\n${tail}`;
+  } catch {
+    return null;
+  }
+}
+
+type QueryArgs = Parameters<typeof query>[0];
+
+interface QueryWithRetryOpts {
+  label: string;
+  maxAttempts?: number;
+  backoffMs?: number;
+}
+
+// Wraps the SDK's `query()` async iterator with:
+//   1. A bounded retry on "Claude Code process exited" errors that arrive
+//      before any message has been streamed to the caller (mid-stream retry
+//      is unsafe because tool calls may have already produced side effects).
+//   2. A best-effort dump of the latest SDK debug-log tail whenever we give
+//      up, so the failure cause shows up in pm2 logs instead of just an
+//      opaque "exited with code N".
+//
+// The SDK uses a `for await` pattern, so this is exposed as an async
+// generator that the caller can drop in place of `query(...)`.
+export async function* queryWithRetry(
+  args: QueryArgs,
+  opts: QueryWithRetryOpts,
+) {
+  const max = opts.maxAttempts ?? 2;
+  const backoff = opts.backoffMs ?? 1000;
+
+  for (let attempt = 1; attempt <= max; attempt++) {
+    let yielded = 0;
+    const startMs = Date.now();
+    try {
+      for await (const msg of query(args)) {
+        yielded++;
+        yield msg;
+      }
+      if (attempt > 1) {
+        console.warn(`[${opts.label}] recovered on attempt ${attempt}`);
+      }
+      return;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const isExitErr = /Claude Code process (exited|terminated)/.test(message);
+
+      const giveUp = !isExitErr || yielded > 0 || attempt >= max;
+      if (giveUp) {
+        const tail = await readLatestSdkDebugTail(startMs).catch(() => null);
+        if (tail) {
+          console.error(`[${opts.label}] Claude Code debug log tail:\n${tail}`);
+        }
+        throw err;
+      }
+
+      const wait = backoff * attempt;
+      console.warn(
+        `[${opts.label}] attempt ${attempt} failed (${message}); retrying in ${wait}ms`,
+      );
+      await sleep(wait);
+    }
+  }
+}

--- a/server/interaction-agent.ts
+++ b/server/interaction-agent.ts
@@ -1,4 +1,5 @@
-import { query, tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import { tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import { queryWithRetry } from "./agent-query.js";
 import { z } from "zod";
 import { api } from "../convex/_generated/api.js";
 import { convex } from "./convex-client.js";
@@ -293,60 +294,63 @@ export async function handleUserMessage(opts: HandleOpts): Promise<string> {
   let reply = "";
   let usage: UsageTotals = { ...EMPTY_USAGE };
   try {
-    for await (const msg of query({
-      prompt,
-      options: {
-        systemPrompt,
-        model: requestedModel,
-        mcpServers: {
-          "boop-memory": memoryServer,
-          "boop-spawn": spawnServer,
-          "boop-automations": automationServer,
-          "boop-tasks": taskServer,
-          "boop-draft-decisions": draftDecisionServer,
-          "boop-ack": ackServer,
-          "boop-self": selfServer,
+    for await (const msg of queryWithRetry(
+      {
+        prompt,
+        options: {
+          systemPrompt,
+          model: requestedModel,
+          mcpServers: {
+            "boop-memory": memoryServer,
+            "boop-spawn": spawnServer,
+            "boop-automations": automationServer,
+            "boop-tasks": taskServer,
+            "boop-draft-decisions": draftDecisionServer,
+            "boop-ack": ackServer,
+            "boop-self": selfServer,
+          },
+          allowedTools: [
+            "mcp__boop-memory__write_memory",
+            "mcp__boop-memory__recall",
+            "mcp__boop-spawn__spawn_agent",
+            "mcp__boop-automations__create_automation",
+            "mcp__boop-automations__list_automations",
+            "mcp__boop-automations__toggle_automation",
+            "mcp__boop-automations__delete_automation",
+            "mcp__boop-tasks__create_task",
+            "mcp__boop-tasks__list_tasks",
+            "mcp__boop-tasks__mark_done",
+            "mcp__boop-tasks__update_task",
+            "mcp__boop-draft-decisions__list_drafts",
+            "mcp__boop-draft-decisions__send_draft",
+            "mcp__boop-draft-decisions__reject_draft",
+            "mcp__boop-ack__send_ack",
+            "mcp__boop-self__get_config",
+            "mcp__boop-self__set_model",
+            "mcp__boop-self__list_integrations",
+            "mcp__boop-self__search_composio_catalog",
+            "mcp__boop-self__inspect_toolkit",
+          ],
+          // Belt-and-suspenders: even with bypassPermissions the SDK can leak
+          // its built-ins if we only whitelist. Explicitly block them on the
+          // dispatcher so it MUST spawn a sub-agent for external work.
+          disallowedTools: [
+            "WebSearch",
+            "WebFetch",
+            "Bash",
+            "Read",
+            "Write",
+            "Edit",
+            "Glob",
+            "Grep",
+            "Agent",
+            "Skill",
+          ],
+          permissionMode: "bypassPermissions",
         },
-        allowedTools: [
-          "mcp__boop-memory__write_memory",
-          "mcp__boop-memory__recall",
-          "mcp__boop-spawn__spawn_agent",
-          "mcp__boop-automations__create_automation",
-          "mcp__boop-automations__list_automations",
-          "mcp__boop-automations__toggle_automation",
-          "mcp__boop-automations__delete_automation",
-          "mcp__boop-tasks__create_task",
-          "mcp__boop-tasks__list_tasks",
-          "mcp__boop-tasks__mark_done",
-          "mcp__boop-tasks__update_task",
-          "mcp__boop-draft-decisions__list_drafts",
-          "mcp__boop-draft-decisions__send_draft",
-          "mcp__boop-draft-decisions__reject_draft",
-          "mcp__boop-ack__send_ack",
-          "mcp__boop-self__get_config",
-          "mcp__boop-self__set_model",
-          "mcp__boop-self__list_integrations",
-          "mcp__boop-self__search_composio_catalog",
-          "mcp__boop-self__inspect_toolkit",
-        ],
-        // Belt-and-suspenders: even with bypassPermissions the SDK can leak
-        // its built-ins if we only whitelist. Explicitly block them on the
-        // dispatcher so it MUST spawn a sub-agent for external work.
-        disallowedTools: [
-          "WebSearch",
-          "WebFetch",
-          "Bash",
-          "Read",
-          "Write",
-          "Edit",
-          "Glob",
-          "Grep",
-          "Agent",
-          "Skill",
-        ],
-        permissionMode: "bypassPermissions",
       },
-    })) {
+      { label: `turn ${tag}` },
+    )) {
       if (msg.type === "assistant") {
         for (const block of msg.message.content) {
           if (block.type === "text") {

--- a/server/memory/extract.ts
+++ b/server/memory/extract.ts
@@ -1,4 +1,4 @@
-import { query } from "@anthropic-ai/claude-agent-sdk";
+import { queryWithRetry } from "../agent-query.js";
 import { api } from "../../convex/_generated/api.js";
 import { convex } from "../convex-client.js";
 import { embed } from "../embeddings.js";
@@ -49,14 +49,17 @@ export async function extractAndStore(opts: {
     const payload = `USER: ${opts.userMessage}\n\nASSISTANT: ${opts.assistantReply}`;
     let buffer = "";
     let usage: UsageTotals = { ...EMPTY_USAGE };
-    for await (const msg of query({
-      prompt: payload,
-      options: {
-        systemPrompt: EXTRACTION_PROMPT,
-        model: requestedModel,
-        permissionMode: "bypassPermissions",
+    for await (const msg of queryWithRetry(
+      {
+        prompt: payload,
+        options: {
+          systemPrompt: EXTRACTION_PROMPT,
+          model: requestedModel,
+          permissionMode: "bypassPermissions",
+        },
       },
-    })) {
+      { label: "memory.extract" },
+    )) {
       if (msg.type === "assistant") {
         for (const block of msg.message.content) {
           if (block.type === "text") buffer += block.text;


### PR DESCRIPTION
## Summary

Three intermittent failures over the last 5 days (turns \`cwup6b\`, \`ez7wl5\`, \`x2ty77\`) all surfaced as:

\`\`\`
[turn xxx] query failed Error: Claude Code process exited with code 1
[memory.extract] failed Error: Claude Code process exited with code 1
\`\`\`

Both \`query()\` callsites — the dispatcher and memory extraction — fail simultaneously, and the SDK's \`ProcessTransport\` only includes the exit code in the thrown error. The subprocess's stderr is not captured by the SDK, and the actual cause lives in \`~/.claude/debug/<uuid>.txt\` which we never read. Without instrumentation we cannot tell whether this is a transient API hiccup, a subscription auth refresh, a specific prompt that trips the CLI, or something else.

## Fix

New \`server/agent-query.ts\` exposes \`queryWithRetry()\` — a drop-in async-iterator wrapper around the SDK's \`query()\`:

1. **Bounded retry** on \`Claude Code process exited\` errors that arrive **before any message has been streamed** to the caller. Mid-stream retry is intentionally skipped because tool calls may have already produced side effects (creating a task, writing a memory record, etc) that replaying would double-execute.
2. **Best-effort debug-log dump** when we give up. Picks the most recent \`*.txt\` under \`~/.claude/debug/\` whose mtime is at or after the start of this attempt and tails the last 30 lines into pm2 stderr. The next failure surfaces an actionable cause instead of just \`exited with code 1\`.

Wired into both callsites:
- \`server/interaction-agent.ts\` — dispatcher \`query()\` wrapped, \`label\` set to \`turn <tag>\`.
- \`server/memory/extract.ts\` — extractor \`query()\` wrapped, \`label\` set to \`memory.extract\`.

## What this changes for users

- Most "Claude Code exited 1" turns silently recover on retry instead of replying \"Foi mal — tive um erro processando isso.\" The user never sees the failure.
- When recovery doesn't work (genuine CLI breakage), the next time the failure happens we get the SDK debug log tail in pm2 stderr and can root-cause it for real.

## Test plan

- [x] \`pnpm typecheck\` clean (only the pre-existing \`composio.ts\` \`alias\` error remains, fixed in the passkey-auth branch)
- [x] \`server/agent-query.ts\` imports cleanly via tsx, exports \`queryWithRetry\`
- [ ] After deploy: next intermittent failure logs an SDK debug-log tail in pm2 stderr
- [ ] After deploy: any recovered retry logs \`[turn xxx] recovered on attempt 2\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)