### PR TITLE
feat(banking): get_balance tool + pluggy_accounts cache + refresh_pluggy_data

### DIFF
--- a/server/finance/accounts.ts
+++ b/server/finance/accounts.ts
@@ -1,0 +1,168 @@
+import type { DatabaseSync } from "node:sqlite";
+import { getFinanceDb } from "./db.js";
+import { getPluggyClient } from "./pluggy.js";
+
+export interface CachedAccount {
+  accountId: string;
+  pluggyItemId: string;
+  name: string;
+  type: string;
+  subtype: string | null;
+  balance: number | null;
+  currencyCode: string | null;
+  pluggyUpdatedAt: string | null;
+  cachedAt: string;
+}
+
+interface AccountRow {
+  account_id: string;
+  pluggy_item_id: string;
+  name: string;
+  type: string;
+  subtype: string | null;
+  balance: number | null;
+  currency_code: string | null;
+  pluggy_updated_at: string | null;
+  cached_at: string;
+}
+
+function rowToCached(row: AccountRow): CachedAccount {
+  return {
+    accountId: row.account_id,
+    pluggyItemId: row.pluggy_item_id,
+    name: row.name,
+    type: row.type,
+    subtype: row.subtype,
+    balance: row.balance,
+    currencyCode: row.currency_code,
+    pluggyUpdatedAt: row.pluggy_updated_at,
+    cachedAt: row.cached_at,
+  };
+}
+
+// "Stale" means the cached row was written on a different calendar day in
+// the user's timezone. Comparing YYYY-MM-DD strings sidesteps the offset
+// arithmetic the wall-clock-to-UTC-ms helpers in task-tools.ts have to do.
+export function isStaleForToday(cachedAtIso: string, timeZone: string): boolean {
+  const fmt = (d: Date) =>
+    new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(d);
+  const cachedDay = fmt(new Date(cachedAtIso));
+  const todayDay = fmt(new Date());
+  return cachedDay !== todayDay;
+}
+
+function readCachedAccounts(db: DatabaseSync, itemId: string): CachedAccount[] {
+  const rows = db
+    .prepare(
+      `SELECT account_id, pluggy_item_id, name, type, subtype, balance,
+              currency_code, pluggy_updated_at, cached_at
+       FROM pluggy_accounts WHERE pluggy_item_id = ?`,
+    )
+    .all(itemId) as unknown as AccountRow[];
+  return rows.map(rowToCached);
+}
+
+async function fetchAndUpsertAccounts(itemId: string): Promise<CachedAccount[]> {
+  const client = getPluggyClient();
+  if (!client) {
+    throw new Error("Pluggy is not configured. Set PLUGGY_CLIENT_ID and PLUGGY_CLIENT_SECRET.");
+  }
+  const response = await client.fetchAccounts(itemId);
+  const accounts = response.results ?? [];
+  const db = getFinanceDb();
+  const upsert = db.prepare(
+    `INSERT INTO pluggy_accounts
+       (account_id, pluggy_item_id, name, type, subtype, balance,
+        currency_code, pluggy_updated_at, cached_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+     ON CONFLICT(account_id) DO UPDATE SET
+       pluggy_item_id = excluded.pluggy_item_id,
+       name = excluded.name,
+       type = excluded.type,
+       subtype = excluded.subtype,
+       balance = excluded.balance,
+       currency_code = excluded.currency_code,
+       pluggy_updated_at = excluded.pluggy_updated_at,
+       cached_at = excluded.cached_at`,
+  );
+
+  db.exec("BEGIN");
+  try {
+    for (const a of accounts) {
+      // For CREDIT accounts, Pluggy's `balance` is the outstanding amount the
+      // user owes. For "how much credit do I have available?" we need
+      // `creditData.availableCreditLimit`. Collapse it into the single
+      // `balance` column so aggregation stays trivial; revisit if a future
+      // slice needs the outstanding amount alongside.
+      const effectiveBalance =
+        a.type === "CREDIT"
+          ? (a.creditData?.availableCreditLimit ?? 0)
+          : typeof a.balance === "number"
+            ? a.balance
+            : null;
+      upsert.run(
+        a.id,
+        itemId,
+        a.name ?? "",
+        a.type ?? "",
+        a.subtype ?? null,
+        effectiveBalance,
+        a.currencyCode ?? null,
+        null,
+      );
+    }
+    db.exec("COMMIT");
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
+
+  // Update parent item's last_sync_at so the items list reflects activity.
+  db.prepare(
+    "UPDATE pluggy_items SET last_sync_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE item_id = ?",
+  ).run(itemId);
+
+  return readCachedAccounts(db, itemId);
+}
+
+export async function getOrRefreshAccounts(
+  itemId: string,
+  timeZone: string,
+): Promise<{ accounts: CachedAccount[]; refreshed: boolean }> {
+  const db = getFinanceDb();
+  const cached = readCachedAccounts(db, itemId);
+  const stale = cached.length === 0 || cached.some((a) => isStaleForToday(a.cachedAt, timeZone));
+  if (!stale) {
+    return { accounts: cached, refreshed: false };
+  }
+  const fresh = await fetchAndUpsertAccounts(itemId);
+  return { accounts: fresh, refreshed: true };
+}
+
+export async function forceRefreshAccounts(itemId: string): Promise<CachedAccount[]> {
+  return fetchAndUpsertAccounts(itemId);
+}
+
+export interface ActiveItem {
+  itemId: string;
+  alias: string;
+  connectorId: number | null;
+}
+
+export function listActiveItems(alias?: string): ActiveItem[] {
+  const db = getFinanceDb();
+  const sql = alias
+    ? "SELECT item_id, alias, connector_id FROM pluggy_items WHERE status = 'active' AND alias = ?"
+    : "SELECT item_id, alias, connector_id FROM pluggy_items WHERE status = 'active'";
+  const rows = (alias ? db.prepare(sql).all(alias) : db.prepare(sql).all()) as unknown as Array<{
+    item_id: string;
+    alias: string;
+    connector_id: number | null;
+  }>;
+  return rows.map((r) => ({ itemId: r.item_id, alias: r.alias, connectorId: r.connector_id }));
+}

--- a/server/finance/mcp.ts
+++ b/server/finance/mcp.ts
@@ -1,0 +1,204 @@
+import { tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import {
+  forceRefreshAccounts,
+  getOrRefreshAccounts,
+  listActiveItems,
+  type CachedAccount,
+} from "./accounts.js";
+import { logFinanceAudit } from "./audit.js";
+
+interface FinanceMcpOptions {
+  userTimeZone: string;
+}
+
+interface BalanceAggregate {
+  checking: number;
+  savings: number;
+  credit_available: number;
+  total: number;
+  currency_code: string;
+}
+
+interface PerAccountBreakdown {
+  alias: string;
+  accounts: Array<{
+    name: string;
+    type: string;
+    subtype: string | null;
+    balance: number | null;
+    currency_code: string | null;
+  }>;
+}
+
+const BRL = "BRL";
+
+function aggregateByType(accounts: CachedAccount[]): BalanceAggregate {
+  let checking = 0;
+  let savings = 0;
+  let creditAvailable = 0;
+  for (const a of accounts) {
+    const balance = typeof a.balance === "number" ? a.balance : 0;
+    if (a.type === "BANK" && a.subtype === "CHECKING_ACCOUNT") {
+      checking += balance;
+    } else if (a.type === "BANK" && a.subtype === "SAVINGS_ACCOUNT") {
+      savings += balance;
+    } else if (a.type === "CREDIT") {
+      creditAvailable += balance;
+    }
+  }
+  return {
+    checking,
+    savings,
+    credit_available: creditAvailable,
+    total: checking + savings + creditAvailable,
+    // All Pluggy BR accounts return BRL today; if a non-BRL account ever
+    // appears the aggregate is meaningless, but we keep the field so the
+    // agent can reason about it.
+    currency_code: BRL,
+  };
+}
+
+function toBreakdown(alias: string, accounts: CachedAccount[]): PerAccountBreakdown {
+  return {
+    alias,
+    accounts: accounts.map((a) => ({
+      name: a.name,
+      type: a.type,
+      subtype: a.subtype,
+      balance: a.balance,
+      currency_code: a.currencyCode,
+    })),
+  };
+}
+
+export function createFinanceMcp(opts: FinanceMcpOptions) {
+  const { userTimeZone } = opts;
+
+  return createSdkMcpServer({
+    name: "boop-finance",
+    version: "0.1.0",
+    tools: [
+      tool(
+        "get_balance",
+        // Intent-driven description: tell the agent WHAT this answers, not
+        // which user phrases trigger it. The dispatcher decides routing
+        // based on the user's intent.
+        "Returns the user's current account balances from cached Pluggy data. " +
+          "Without an item_alias, returns aggregated totals by account type " +
+          "({ checking, savings, credit_available, total }) across all " +
+          "registered banks. With an item_alias, returns a per-account " +
+          "breakdown for that one bank. Cached data is refreshed lazily once " +
+          "per calendar day; if the user explicitly asks to refresh, use " +
+          "refresh_pluggy_data instead.",
+        { item_alias: z.string().optional() },
+        async (args) => {
+          const started = Date.now();
+          try {
+            const items = listActiveItems(args.item_alias);
+            if (items.length === 0) {
+              const message = args.item_alias
+                ? `No active item registered for alias "${args.item_alias}".`
+                : "No active items registered. Use POST /api/finance/items to add one.";
+              logFinanceAudit({
+                source: "tool_call",
+                action: "get_balance",
+                payload: args,
+                result: { error: message },
+                durationMs: Date.now() - started,
+              });
+              return { content: [{ type: "text", text: message }] };
+            }
+
+            const allAccounts: CachedAccount[] = [];
+            const refreshed: string[] = [];
+            for (const item of items) {
+              const result = await getOrRefreshAccounts(item.itemId, userTimeZone);
+              if (result.refreshed) refreshed.push(item.alias);
+              allAccounts.push(...result.accounts);
+            }
+
+            const body = args.item_alias
+              ? toBreakdown(args.item_alias, allAccounts)
+              : aggregateByType(allAccounts);
+
+            logFinanceAudit({
+              source: "tool_call",
+              action: "get_balance",
+              payload: args,
+              result: { refreshed, accountCount: allAccounts.length },
+              durationMs: Date.now() - started,
+            });
+
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({ balance: body, refreshed }),
+                },
+              ],
+            };
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            logFinanceAudit({
+              source: "tool_call",
+              action: "get_balance",
+              payload: args,
+              result: { error: message },
+              durationMs: Date.now() - started,
+            });
+            return { content: [{ type: "text", text: `error: ${message}` }] };
+          }
+        },
+      ),
+      tool(
+        "refresh_pluggy_data",
+        "Forces a fresh fetch from Pluggy for the user's registered bank " +
+          "items, bypassing the daily cache. Use this when the user " +
+          "explicitly asks to update or refresh their financial data. " +
+          "Returns the per-item refresh result.",
+        { item_alias: z.string().optional() },
+        async (args) => {
+          const started = Date.now();
+          try {
+            const items = listActiveItems(args.item_alias);
+            if (items.length === 0) {
+              const message = args.item_alias
+                ? `No active item registered for alias "${args.item_alias}".`
+                : "No active items registered. Use POST /api/finance/items to add one.";
+              return { content: [{ type: "text", text: message }] };
+            }
+
+            const results: Array<{ alias: string; accountCount: number }> = [];
+            for (const item of items) {
+              const accounts = await forceRefreshAccounts(item.itemId);
+              results.push({ alias: item.alias, accountCount: accounts.length });
+            }
+
+            logFinanceAudit({
+              source: "tool_call",
+              action: "refresh_pluggy_data",
+              payload: args,
+              result: { results },
+              durationMs: Date.now() - started,
+            });
+
+            return {
+              content: [{ type: "text", text: JSON.stringify({ refreshed: results }) }],
+            };
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            logFinanceAudit({
+              source: "tool_call",
+              action: "refresh_pluggy_data",
+              payload: args,
+              result: { error: message },
+              durationMs: Date.now() - started,
+            });
+            return { content: [{ type: "text", text: `error: ${message}` }] };
+          }
+        },
+      ),
+    ],
+  });
+}

--- a/server/finance/migrations/002_pluggy_accounts.sql
+++ b/server/finance/migrations/002_pluggy_accounts.sql
@@ -1,0 +1,13 @@
+CREATE TABLE pluggy_accounts (
+  account_id TEXT PRIMARY KEY,
+  pluggy_item_id TEXT NOT NULL REFERENCES pluggy_items(item_id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  type TEXT NOT NULL,
+  subtype TEXT,
+  balance REAL,
+  currency_code TEXT,
+  pluggy_updated_at TEXT,
+  cached_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX idx_accounts_item_id ON pluggy_accounts (pluggy_item_id);

--- a/server/interaction-agent.ts
+++ b/server/interaction-agent.ts
@@ -10,6 +10,7 @@ import { createAutomationMcp } from "./automation-tools.js";
 import { createTaskMcp, resolveTaskTimeZone } from "./task-tools.js";
 import { createDraftDecisionMcp } from "./draft-tools.js";
 import { createSelfMcp } from "./self-tools.js";
+import { createFinanceMcp } from "./finance/mcp.js";
 import { getRuntimeModel } from "./runtime-config.js";
 import { broadcast } from "./broadcast.js";
 import { sendTelegramMessage } from "./telegram.js";
@@ -203,6 +204,17 @@ These are cheap and synchronous — no ack required. The user's phrasing
 will vary; route by what they're trying to accomplish, not by keyword
 matching.
 
+Banking (Pluggy-backed):
+When the user wants to know how much money they have, what their balance
+is, or how they're doing across accounts → get_balance. Default behavior
+returns the aggregate ({ checking, savings, credit_available, total } in
+BRL); pass item_alias only when the user is clearly asking about one
+specific bank. Cached data refreshes lazily once per day; if the user
+explicitly asks to update or refresh ("atualiza meus dados", "puxa o
+extrato novo") use refresh_pluggy_data instead. Privacy: never relay raw
+transaction lines, account numbers, or merchants — these tools return
+aggregates only, and that is the boundary you must keep.
+
 Time / timezone:
 The user has a saved timezone in get_config.userTimezone. Whenever your reply
 or a sub-agent's task depends on local time (deadlines, "today", "9am
@@ -254,6 +266,7 @@ export async function handleUserMessage(opts: HandleOpts): Promise<string> {
   const taskServer = createTaskMcp(opts.conversationId, { userTimeZone: taskTimeZone });
   const draftDecisionServer = createDraftDecisionMcp(opts.conversationId);
   const selfServer = createSelfMcp();
+  const financeServer = createFinanceMcp({ userTimeZone: taskTimeZone });
 
   const ackServer = createSdkMcpServer({
     name: "boop-ack",
@@ -375,6 +388,7 @@ export async function handleUserMessage(opts: HandleOpts): Promise<string> {
             "boop-draft-decisions": draftDecisionServer,
             "boop-ack": ackServer,
             "boop-self": selfServer,
+            "boop-finance": financeServer,
           },
           allowedTools: [
             "mcp__boop-memory__write_memory",
@@ -398,6 +412,8 @@ export async function handleUserMessage(opts: HandleOpts): Promise<string> {
             "mcp__boop-self__list_integrations",
             "mcp__boop-self__search_composio_catalog",
             "mcp__boop-self__inspect_toolkit",
+            "mcp__boop-finance__get_balance",
+            "mcp__boop-finance__refresh_pluggy_data",
           ],
           // Belt-and-suspenders: even with bypassPermissions the SDK can leak
           // its built-ins if we only whitelist. Explicitly block them on the


### PR DESCRIPTION
## Summary

Closes #28. First end-to-end financial query path. Asking Boop "qual meu saldo?" now aggregates across the user's registered Pluggy items, with a daily lazy-refresh cache and an explicit force-refresh escape hatch.

- **Migration 002_pluggy_accounts.sql** — adds the table per the AC schema (\`account_id\` PK, \`pluggy_item_id\` FK to \`pluggy_items\`, name, type, subtype, balance, currency_code, pluggy_updated_at, cached_at) plus an \`idx_accounts_item_id\` index for the per-item lookups the cache fetcher does.
- **\`server/finance/accounts.ts\`** — exposes \`getOrRefreshAccounts(itemId, timeZone)\` and \`forceRefreshAccounts(itemId)\`. Cache is "stale for today" iff \`cached_at\` falls on a different \`YYYY-MM-DD\` in \`BOOP_USER_TIME_ZONE\`. Comparing date strings via \`Intl.DateTimeFormat("en-CA")\` sidesteps the wall-clock-to-UTC-ms offset arithmetic the task-tools helpers have to do.
- **CREDIT account handling** — Pluggy's \`balance\` for credit cards is the outstanding amount the user owes; for \`credit_available\` we want \`creditData.availableCreditLimit\`. We collapse that into the single \`balance\` column so type-based aggregation stays trivial. Outstanding balance is intentionally not stored yet — future slices can add a column when needed.
- **\`server/finance/mcp.ts\` (\`createFinanceMcp\`)** — wires two tools, both with intent-driven descriptions (no literal trigger lists):
  - \`get_balance({ item_alias? })\` — returns \`{ checking, savings, credit_available, total }\` aggregated by type when no alias, or per-account breakdown for one bank when \`item_alias\` is set.
  - \`refresh_pluggy_data({ item_alias? })\` — bypasses the daily cache freshness check.
  - Both calls log to \`finance_audit_log\` with payload, result, and elapsed ms.
- **Dispatcher prompt** gets a "Banking" section that guards against relaying raw transactions/merchants (privacy L1: only aggregates leave this surface).

## Stack

This PR is stacked on:
- jrflga#41 (Banking #27 Pluggy register) → jrflga#33 (Banking #26 SQLite skeleton) → jrflga#38 (passkey-auth + dashboard SPA)

Recommended merge order: #38 → #33 → #41 → this. Diff above will collapse incrementally as each predecessor lands.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] Boots clean from empty data dir; \`[finance] applied migrations: 001_initial, 002_pluggy_accounts\`
- [x] Boots clean from existing data dir (idempotent); migrations skipped
- [ ] Manual smoke (requires a registered Pluggy item):
  - [ ] Ask Boop "qual meu saldo?" → returns aggregated totals
  - [ ] Ask Boop "atualiza meus dados" → forces a Pluggy refetch
  - [ ] \`GET /api/finance/audit?limit=10\` shows \`get_balance\` and \`refresh_pluggy_data\` rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)