### PR TITLE
fix(banking): ack Pluggy webhook probe + unknown payloads with 200

### DIFF
--- a/server/finance/webhook.ts
+++ b/server/finance/webhook.ts
@@ -65,15 +65,36 @@ export function createPluggyWebhookRouter(): express.Router {
       }
     }
 
+    // Be liberal with the body: the Pluggy dashboard does a connectivity
+    // probe (often empty body) when saving a webhook URL, and a 4xx makes
+    // it report "Failed to register webhook." Same for events we don't
+    // know yet — we'd rather ack and audit than 4xx and force a retry.
     const parsed = WebhookBody.safeParse(req.body ?? {});
     if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.message });
+      logFinanceAudit({
+        source: "webhook",
+        action: "probe_or_invalid",
+        payload: req.body ?? null,
+        result: { error: parsed.error.message },
+        durationMs: Date.now() - started,
+      });
+      res.json({ ok: true, ignored: "unrecognized payload" });
       return;
     }
 
     const { event, eventId, clientUserId, itemId } = parsed.data;
     if (!itemId && event !== "connector/status_updated") {
-      res.status(400).json({ error: "itemId is required for this webhook event" });
+      // Same rationale: ack with audit so Pluggy doesn't keep retrying
+      // legitimate-but-unhandled events. We log enough to debug if
+      // something material is being silently dropped.
+      logFinanceAudit({
+        source: "webhook",
+        action: event,
+        payload: { event, eventId, clientUserId, itemId },
+        result: { ignored: "missing itemId" },
+        durationMs: Date.now() - started,
+      });
+      res.json({ ok: true, ignored: "missing itemId" });
       return;
     }
 


### PR DESCRIPTION
## Summary
- Pluggy's dashboard \"Save & Test Webhook\" POSTs an empty body and treats anything other than 2XX as a failure. The strict zod-validated handler returned 400 in that case, so the URL couldn't be saved from the dashboard.
- Loosen the contract: when the body doesn't match the schema, log a \`probe_or_invalid\` audit row and return \`{ ok: true, ignored: ... }\`. Same for legitimate events that arrive without an \`itemId\` (\`item/error\` without context, future event types, etc.) — ack + audit beats forcing Pluggy to retry something we'd silently ignore anyway.
- The 401 path on \`PLUGGY_WEBHOOK_SECRET\` mismatch is unchanged: probes from non-Pluggy callers still get rejected when the secret is set.

Follow-up to #43.

## Test plan
- [ ] \`pnpm tsc --noEmit\` — done locally
- [ ] After deploy, \`curl -X POST https://<host>/webhooks/pluggy -H 'Content-Type: application/json' -d '{}'\` returns 200
- [ ] Pluggy dashboard \"Save & Test Webhook\" succeeds for the configured URL
- [ ] With \`PLUGGY_WEBHOOK_SECRET\` set, the same curl without the header returns 401
- [ ] A real \`item/updated\` event still triggers the accounts refresh + audit row (smoke from a sandbox connection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)