### PR TITLE
fix(ci): build debug UI on deploy so SPA fallback stops ENOENTing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,10 +89,16 @@ jobs:
           echo "[1/3] git fetch + reset to origin/main (as $APP_USER)"
           sudo -u "$APP_USER" git fetch --prune origin
           sudo -u "$APP_USER" git reset --hard origin/main
-          echo "[2/3] pnpm install --frozen-lockfile (as $APP_USER)"
+          echo "[2/4] pnpm install --frozen-lockfile (as $APP_USER)"
           corepack enable
           sudo -u "$APP_USER" -H bash -c "cd '$INSTALL_DIR' && CI=true corepack pnpm install --frozen-lockfile"
-          echo "[3/3] pm2 restart $PM2_PROCESS"
+          # debug/dist/ is gitignored; the server's SPA fallback in
+          # server/index.ts sendFile()s debug/dist/index.html on every
+          # HTML GET, so a deploy without this step ENOENTs the dashboard
+          # (and any new debug UI from this push, e.g. PluggySection).
+          echo "[3/4] pnpm build:debug (as $APP_USER)"
+          sudo -u "$APP_USER" -H bash -c "cd '$INSTALL_DIR' && CI=true corepack pnpm build:debug"
+          echo "[4/4] pm2 restart $PM2_PROCESS"
           # Override HOME/USER/LOGNAME so pm2 --update-env stamps the
           # spawned process with the app user's identity instead of
           # root's. PM2_HOME pins the daemon location so pm2 still


### PR DESCRIPTION
## Summary
- \`debug/dist/\` is gitignored and the deploy workflow only ran \`pnpm install --frozen-lockfile\`, so on a fresh VPS \`server/index.ts\`'s SPA fallback (\`sendFile(debug/dist/index.html)\`) ENOENTs on every HTML GET — including the new \`PluggySection\` shipped with #43.
- Add \`[3/4] pnpm build:debug\` under the same \`sudo -u $APP_USER\` context as install so the dashboard is materialised before pm2 restarts.

## Test plan
- [ ] Push to main triggers the workflow; the \`vps\` job logs \`[3/4] pnpm build:debug\` between install and pm2 restart
- [ ] After deploy, \`curl -I https://<host>/\` returns 200 with \`text/html\`
- [ ] Dashboard \`Connections\` tab loads and shows the new \`Pluggy connect\` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)