### PR TITLE
fix(banking): Pluggy webhook GET handler + received:true response shape

### DIFF
--- a/server/finance/webhook.ts
+++ b/server/finance/webhook.ts
@@ -48,6 +48,15 @@ async function syncItem(itemId: string, event: string, aliasFallback?: string | 
 export function createPluggyWebhookRouter(): express.Router {
   const router = express.Router();
 
+  // Some webhook providers (and reverse proxies / uptime checks) probe a
+  // URL with GET before accepting it. Without an explicit handler, the
+  // request falls through to the SPA fallback in server/index.ts, which
+  // ENOENTs on a fresh deploy and surfaces as a 404 HTML page — exactly
+  // the shape that makes a Pluggy "Save & Test Webhook" probe fail.
+  router.get("/", (_req, res) => {
+    res.json({ received: true, ok: true });
+  });
+
   router.post("/", async (req, res) => {
     const started = Date.now();
 
@@ -78,7 +87,7 @@ export function createPluggyWebhookRouter(): express.Router {
         result: { error: parsed.error.message },
         durationMs: Date.now() - started,
       });
-      res.json({ ok: true, ignored: "unrecognized payload" });
+      res.json({ received: true, ok: true, ignored: "unrecognized payload" });
       return;
     }
 
@@ -94,7 +103,7 @@ export function createPluggyWebhookRouter(): express.Router {
         result: { ignored: "missing itemId" },
         durationMs: Date.now() - started,
       });
-      res.json({ ok: true, ignored: "missing itemId" });
+      res.json({ received: true, ok: true, ignored: "missing itemId" });
       return;
     }
 
@@ -117,7 +126,7 @@ export function createPluggyWebhookRouter(): express.Router {
         durationMs: Date.now() - started,
       });
 
-      res.json({ ok: true });
+      res.json({ received: true, ok: true });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logFinanceAudit({
@@ -127,7 +136,7 @@ export function createPluggyWebhookRouter(): express.Router {
         result: { error: message },
         durationMs: Date.now() - started,
       });
-      res.status(200).json({ ok: false, error: message });
+      res.status(200).json({ received: true, ok: false, error: message });
     }
   });
 


### PR DESCRIPTION
## Summary

Pluggy's \"Save & Test Webhook\" probe still rejected the URL after #44.
Two follow-up fixes:

1. **\`GET /webhooks/pluggy\` returns 200.** Verified independently via \`curl -X GET https://<host>/webhooks/pluggy\` returning 404 with \`<pre>Error: ENOENT: no such file or directory, stat .../debug/dist/index.html</pre>\` — the request was falling through to the SPA fallback in \`server/index.ts\`, which sendFile()s the dashboard index that doesn't exist on a fresh deploy until #45 lands. Either way a webhook URL shouldn't double as a SPA route.

2. **POST responses now include \`received: true\`.** Pluggy's own \"Copy for AI\" example in their dashboard returns \`Response.json({ received: true })\`, suggesting their probe checks for that field. Additive — kept the existing \`ok\` / \`ignored\` / \`error\` fields so audit consumers don't break.

Follow-up to #44.

## Test plan
- [ ] \`pnpm tsc --noEmit\` — done locally
- [ ] After deploy, \`curl https://<host>/webhooks/pluggy\` returns \`{\"received\":true,\"ok\":true}\`
- [ ] Pluggy dashboard \"Save & Test Webhook\" + \"Finish Setup\" succeed
- [ ] With \`PLUGGY_WEBHOOK_SECRET\` set, POST without the matching header still returns 401 (security path unchanged)
- [ ] A real \`item/updated\` from a sandbox connection still triggers the accounts refresh + audit row

🤖 Generated with [Claude Code](https://claude.com/claude-code)