### PR TITLE
ci: post Telegram changelog on every PR merge

### DIFF
--- a/.github/workflows/changelog-notify.yml
+++ b/.github/workflows/changelog-notify.yml
@@ -1,0 +1,61 @@
+name: Changelog notify
+
+# Posts a plain-text summary to the Telegram chat every time a PR
+# merges into main. Direct sendMessage via Bot API: no agent in the
+# loop, no boop-agent restart required, no Convex write — just a
+# notification mirroring the deploy pipeline.
+#
+# Required repo secrets:
+#   TELEGRAM_BOT_TOKEN  same value as the runtime env on the VPS
+#   TELEGRAM_CHAT_ID    target chat (single-user fork: the maintainer's chat)
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  notify:
+    name: Send merge to Telegram
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Post to Telegram
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -eu
+          if [ -z "${TELEGRAM_BOT_TOKEN}" ] || [ -z "${TELEGRAM_CHAT_ID}" ]; then
+            echo "::warning::TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set; skipping."
+            exit 0
+          fi
+
+          BODY="${PR_BODY:-(sem descrição)}"
+          # Telegram caps a single message at 4096 chars; keep headroom for
+          # the title + URL + author and the empty lines between them.
+          if [ "${#BODY}" -gt 1500 ]; then
+            BODY="${BODY:0:1500}
+
+... (truncado, ver PR completo)"
+          fi
+
+          MESSAGE="PR #${PR_NUMBER} merged
+
+${PR_TITLE}
+
+${BODY}
+
+${PR_URL}"
+
+          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MESSAGE}" \
+            --data-urlencode "disable_web_page_preview=true" \
+            -o /dev/null
+          echo "Notified PR #${PR_NUMBER} merge to chat ${TELEGRAM_CHAT_ID}."


### PR DESCRIPTION
## Summary

New workflow that fires on every PR merge and posts a plain-text changelog directly to Telegram via the Bot API. Runs in parallel with \`deploy.yml\`, no agent involvement, no restart needed.

**Format of the message** (plain text, no parse_mode):
\`\`\`
PR #NN merged

<title>

<body, truncated to 1500 chars>

<html_url>
\`\`\`

Body cap of 1500 chars leaves headroom inside Telegram's 4096 char single-message limit. Long PRs get a \`(truncado, ver PR completo)\` suffix.

## Required secrets (add before merge)

| Name | Value |
|---|---|
| \`TELEGRAM_BOT_TOKEN\` | Same value as the runtime env on the VPS (\`/opt/boop-agent/.env.local\`) |
| \`TELEGRAM_CHAT_ID\` | Maintainer's chat ID (single-user fork) |

If either is missing the workflow logs a warning and exits 0, so a missing secret never blocks the merge — but no Telegram notice is sent until both are added.

CLI helpers if you want:
\`\`\`bash
gh secret set TELEGRAM_BOT_TOKEN --repo jrflga/boop-agent
gh secret set TELEGRAM_CHAT_ID --repo jrflga/boop-agent
\`\`\`

## Test plan
- [ ] Add the two repo secrets
- [ ] Merge this PR; the workflow itself runs against this very merge and posts the first changelog
- [ ] Verify the Telegram chat receives a single plain-text message with PR #, title, body, URL
- [ ] Long PR bodies get truncated with the suffix instead of failing the API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)